### PR TITLE
Add cookie notice to all case studies pages

### DIFF
--- a/casestudies/1/casestudy/www/layout/case_id_1.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_18.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_18.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_19.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_19.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_1_c_bio.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_1_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_20.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_20.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_21.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_21.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_2_c_bio.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_2_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_35.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_35.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_36.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_36.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_37.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_37.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_38_pid_37.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_38_pid_37.html
@@ -79,6 +79,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_39_pid_37.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_39_pid_37.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_3_c_bio.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_3_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_40_pid_37.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_40_pid_37.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_41_pid_37.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_41_pid_37.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_45.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_45.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_47_pid_45.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_47_pid_45.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_48_pid_45.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_48_pid_45.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_49_pid_45.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_49_pid_45.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_50_pid_45.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_50_pid_45.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_51.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_51.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_52.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_52.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_53.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_53.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_54.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_54.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/1/casestudy/www/layout/case_id_1_id_55.html
+++ b/casestudies/1/casestudy/www/layout/case_id_1_id_55.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/106/casestudy/www/layout/case_id_106.html
+++ b/casestudies/106/casestudy/www/layout/case_id_106.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_216_c_bio.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_216_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_217_c_bio.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_217_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_730.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_730.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_731.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_731.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_732.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_732.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_733.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_733.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_734.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_734.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_735.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_735.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_736.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_736.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_737.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_737.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_738.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_738.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/108/casestudy/www/layout/case_id_108_id_739.html
+++ b/casestudies/108/casestudy/www/layout/case_id_108_id_739.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_211_c_bio.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_211_c_bio.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_212_c_bio.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_212_c_bio.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_213_c_bio.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_213_c_bio.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_214_c_bio.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_214_c_bio.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_215_c_bio.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_215_c_bio.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_741.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_741.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_742.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_742.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_743.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_743.html
@@ -66,6 +66,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_744.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_744.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_745.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_745.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_746.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_746.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_747.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_747.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_748.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_748.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_749.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_749.html
@@ -62,6 +62,8 @@ font-style:italic;
 }
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_750.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_750.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/109/casestudy/www/layout/case_id_109_id_751.html
+++ b/casestudies/109/casestudy/www/layout/case_id_109_id_751.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_218_c_bio.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_218_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_219_c_bio.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_219_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_220_c_bio.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_220_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_753.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_753.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_754.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_754.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_755.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_755.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_756.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_756.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_757.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_757.html
@@ -59,7 +59,9 @@
           font-style:italic;
       }
     </style>
-  </head>
+  <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
 
   <body>
     <div id="container">

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_758.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_758.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_759.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_759.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_760.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_760.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/110/casestudy/www/layout/case_id_110_id_761.html
+++ b/casestudies/110/casestudy/www/layout/case_id_110_id_761.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/111/casestudy/www/layout/case_id_111.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_221_c_bio.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_221_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_222_c_bio.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_222_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_223_c_bio.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_223_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_224_c_bio.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_224_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_763.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_763.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_764.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_764.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_765.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_765.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_766.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_766.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_767.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_767.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_768.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_768.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_769.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_769.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_770.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_770.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_771.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_771.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_772.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_772.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/111/casestudy/www/layout/case_id_111_id_773.html
+++ b/casestudies/111/casestudy/www/layout/case_id_111_id_773.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112.html
@@ -62,6 +62,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_225_c_bio.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_225_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_226_c_bio.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_226_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_227_c_bio.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_227_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_775.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_775.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 <body>
 

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_776.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_776.html
@@ -62,6 +62,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_777.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_777.html
@@ -62,6 +62,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_778.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_778.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_779.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_779.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_780.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_780.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_781.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_781.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_782.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_782.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_783.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_783.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 <body>
 

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_784.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_784.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_785.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_785.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_786.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_786.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_787.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_787.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/112/casestudy/www/layout/case_id_112_id_788.html
+++ b/casestudies/112/casestudy/www/layout/case_id_112_id_788.html
@@ -59,6 +59,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/fusion/nslij.html
+++ b/casestudies/113/casestudy/fusion/nslij.html
@@ -40,7 +40,9 @@
     }
     google.maps.event.addDomListener(window, 'load', initialize);
   </script>
-  </head>
+  <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
   <body>
     <div id="map-canvas"></div>
   </body>

--- a/casestudies/113/casestudy/www/layout/case_id_113.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_228_c_bio.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_228_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_229_c_bio.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_229_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_790.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_790.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_791.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_791.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_792.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_792.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_793.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_793.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_794.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_794.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_795.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_795.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_796.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_796.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/113/casestudy/www/layout/case_id_113_id_797.html
+++ b/casestudies/113/casestudy/www/layout/case_id_113_id_797.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/114/casestudy/www/layout/case_id_114.html
+++ b/casestudies/114/casestudy/www/layout/case_id_114.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_230_c_bio.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_230_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_231_c_bio.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_231_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_232_c_bio.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_232_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_233_c_bio.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_233_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_234_c_bio.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_234_c_bio.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_812.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_812.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_813.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_813.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_814.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_814.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_815.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_815.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_816.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_816.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_817.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_817.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_818.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_818.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_819.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_819.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_820.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_820.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_821.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_821.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_822.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_822.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_823.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_823.html
@@ -64,6 +64,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_824.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_824.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_825.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_825.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_826.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_826.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_827.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_827.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_828.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_828.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_829.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_829.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/115/casestudy/www/layout/case_id_115_id_830.html
+++ b/casestudies/115/casestudy/www/layout/case_id_115_id_830.html
@@ -63,6 +63,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_236_c_bio.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_236_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_237_c_bio.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_237_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_238_c_bio.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_238_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_239_c_bio.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_239_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_240_c_bio.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_240_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_832.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_832.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_833.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_833.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_834.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_834.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_835.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_835.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_836.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_836.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_837.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_837.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_838.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_838.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_839.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_839.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_840.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_840.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/116/casestudy/www/layout/case_id_116_id_841.html
+++ b/casestudies/116/casestudy/www/layout/case_id_116_id_841.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/117/casestudy/www/layout/case_id_117.html
+++ b/casestudies/117/casestudy/www/layout/case_id_117.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/118/casestudy/www/layout/case_id_118.html
+++ b/casestudies/118/casestudy/www/layout/case_id_118.html
@@ -60,6 +60,8 @@
       font-style:italic;
     }
   </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 <body>
   <div id="container">

--- a/casestudies/119/casestudy/www/layout/case_id_119.html
+++ b/casestudies/119/casestudy/www/layout/case_id_119.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_10_c_bio.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_10_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_114.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_114.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_115.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_115.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_116.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_116.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_117.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_117.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_118.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_118.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_119.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_119.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_120.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_120.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_121.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_121.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_123.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_123.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_124.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_124.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_125.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_125.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_126.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_126.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_127.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_127.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_128.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_128.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_129.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_129.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_130.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_130.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_131.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_131.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_132.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_132.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_6_c_bio.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_6_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_7_c_bio.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_7_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_8_c_bio.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_8_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/12/casestudy/www/layout/case_id_12_id_9_c_bio.html
+++ b/casestudies/12/casestudy/www/layout/case_id_12_id_9_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/120/casestudy/www/layout/case_id_120.html
+++ b/casestudies/120/casestudy/www/layout/case_id_120.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/121/casestudy/www/layout/case_id_121.html
+++ b/casestudies/121/casestudy/www/layout/case_id_121.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/122/casestudy/www/layout/case_id_122.html
+++ b/casestudies/122/casestudy/www/layout/case_id_122.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/123/casestudy/www/layout/case_id_123.html
+++ b/casestudies/123/casestudy/www/layout/case_id_123.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_241_c_bio.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_241_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_242_c_bio.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_242_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_243_c_bio.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_243_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_850.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_850.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_851.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_851.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_852.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_852.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_853.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_853.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_854.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_854.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_855.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_855.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_856.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_856.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_857.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_857.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/124/casestudy/www/layout/case_id_124_id_858.html
+++ b/casestudies/124/casestudy/www/layout/case_id_124_id_858.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_244_c_bio.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_244_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_245_c_bio.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_245_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_246_c_bio.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_246_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_247_c_bio.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_247_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_869.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_869.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_870.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_870.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_871.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_871.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_872.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_872.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_873.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_873.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_874.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_874.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_875.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_875.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_876.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_876.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_877.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_877.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/125/casestudy/www/layout/case_id_125_id_878.html
+++ b/casestudies/125/casestudy/www/layout/case_id_125_id_878.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_248_c_bio.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_248_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_249_c_bio.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_249_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_250_c_bio.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_250_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_251_c_bio.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_251_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_861.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_861.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_862.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_862.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_863.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_863.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_864.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_864.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_865.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_865.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_866.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_866.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_867.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_867.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/126/casestudy/www/layout/case_id_126_id_868.html
+++ b/casestudies/126/casestudy/www/layout/case_id_126_id_868.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/127/casestudy/www/layout/case_id_127.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_252_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_252_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_253_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_253_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_254_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_254_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_255_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_255_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_256_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_256_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_257_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_257_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_258_c_bio.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_258_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_884.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_884.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_885.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_885.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_886.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_886.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_887.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_887.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_888.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_888.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_889.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_889.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_892.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_892.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_894.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_894.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/127/casestudy/www/layout/case_id_127_id_895.html
+++ b/casestudies/127/casestudy/www/layout/case_id_127_id_895.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_259_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_259_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_260_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_260_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_261_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_261_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_262_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_262_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_263_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_263_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_264_c_bio.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_264_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_899.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_899.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_900.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_900.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_901.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_901.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_902.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_902.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_903.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_903.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_904.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_904.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_905.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_905.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_906.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_906.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/128/casestudy/www/layout/case_id_128_id_907.html
+++ b/casestudies/128/casestudy/www/layout/case_id_128_id_907.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_265_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_265_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_266_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_266_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_267_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_267_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_268_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_268_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_269_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_269_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_270_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_270_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_271_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_271_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_273_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_273_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_274_c_bio.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_274_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_909.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_909.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_910.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_910.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_911.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_911.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_912.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_912.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_913.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_913.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_914.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_914.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_915.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_915.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/129/casestudy/www/layout/case_id_129_id_916.html
+++ b/casestudies/129/casestudy/www/layout/case_id_129_id_916.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/130/casestudy/www/layout/case_id_130.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_275_c_bio.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_275_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_276_c_bio.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_276_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_277_c_bio.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_277_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_918.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_918.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_919.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_919.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_920.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_920.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_921.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_921.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_922.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_922.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_923.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_923.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_924.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_924.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_925.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_925.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/130/casestudy/www/layout/case_id_130_id_926.html
+++ b/casestudies/130/casestudy/www/layout/case_id_130_id_926.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/131/casestudy/www/layout/case_id_131.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_278_c_bio.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_278_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_279_c_bio.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_279_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_280_c_bio.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_280_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_281_c_bio.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_281_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_282_c_bio.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_282_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_939.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_939.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_940.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_940.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_941.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_941.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_942.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_942.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_943.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_943.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_944.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_944.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_945.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_945.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_946.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_946.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_947.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_947.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/131/casestudy/www/layout/case_id_131_id_966.html
+++ b/casestudies/131/casestudy/www/layout/case_id_131_id_966.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_295_c_bio.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_295_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_296_c_bio.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_296_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_297_c_bio.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_297_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_929.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_929.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_930.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_930.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_931.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_931.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_932.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_932.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_933.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_933.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_934.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_934.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_935.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_935.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_936.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_936.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_937.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_937.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/132/casestudy/www/layout/case_id_132_id_938.html
+++ b/casestudies/132/casestudy/www/layout/case_id_132_id_938.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_283_c_bio.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_283_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_284_c_bio.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_284_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_285_c_bio.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_285_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_286_c_bio.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_286_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_287_c_bio.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_287_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_949.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_949.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_950.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_950.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_951.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_951.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_952.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_952.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_953.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_953.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_954.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_954.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_955.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_955.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_956.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_956.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_957.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_957.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_958.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_958.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_959.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_959.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_960.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_960.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_961.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_961.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_962.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_962.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_963.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_963.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_964.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_964.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/133/casestudy/www/layout/case_id_133_id_965.html
+++ b/casestudies/133/casestudy/www/layout/case_id_133_id_965.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_288_c_bio.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_288_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_289_c_bio.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_289_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_290_c_bio.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_290_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_291_c_bio.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_291_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_968.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_968.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_969.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_969.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_970.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_970.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_971.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_971.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_972.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_972.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_973.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_973.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_974.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_974.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_975.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_975.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_976.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_976.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/134/casestudy/www/layout/case_id_134_id_977.html
+++ b/casestudies/134/casestudy/www/layout/case_id_134_id_977.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_292_c_bio.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_292_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_293_c_bio.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_293_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_294_c_bio.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_294_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_979.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_979.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_980.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_980.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_981.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_981.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_982.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_982.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_983.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_983.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_984.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_984.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_985.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_985.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_986.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_986.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_987.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_987.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_988.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_988.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_989.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_989.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_990.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_990.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_991.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_991.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_992.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_992.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_993.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_993.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_994.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_994.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/135/casestudy/www/layout/case_id_135_id_995.html
+++ b/casestudies/135/casestudy/www/layout/case_id_135_id_995.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/136/casestudy/www/layout/case_id_136.html
+++ b/casestudies/136/casestudy/www/layout/case_id_136.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_138.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_138.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_139.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_139.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_140.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_140.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_141.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_141.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_142.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_142.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_143.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_143.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_144.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_144.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_145.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_145.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_146.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_146.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_147.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_147.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_148.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_148.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_149.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_149.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_150.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_150.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_151.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_151.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_152.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_152.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_153.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_153.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_154.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_154.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_155.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_155.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_156.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_156.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_74_c_bio.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_74_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_75_c_bio.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_75_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_76_c_bio.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_76_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_77_c_bio.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_77_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/14/casestudy/www/layout/case_id_14_id_78_c_bio.html
+++ b/casestudies/14/casestudy/www/layout/case_id_14_id_78_c_bio.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/142/casestudy/www/layout/case_id_142.html
+++ b/casestudies/142/casestudy/www/layout/case_id_142.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1001.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1001.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1002.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1002.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1004.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1004.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1005.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1005.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1006.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1006.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1007.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1007.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1008.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1008.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1009.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1009.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1010.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1010.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_1011.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_1011.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_298_c_bio.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_298_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_299_c_bio.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_299_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_300_c_bio.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_300_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_301_c_bio.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_301_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/146/casestudy/www/layout/case_id_146_id_999.html
+++ b/casestudies/146/casestudy/www/layout/case_id_146_id_999.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1013.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1013.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1014.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1014.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1015.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1015.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1016.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1016.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1017.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1017.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1018.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1018.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1019.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1019.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1020.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1020.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1021.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1021.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_1022.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_1022.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_302_c_bio.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_302_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_303_c_bio.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_303_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/147/casestudy/www/layout/case_id_147_id_304_c_bio.html
+++ b/casestudies/147/casestudy/www/layout/case_id_147_id_304_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/148/casestudy/www/layout/case_id_148.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1025.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1025.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1026.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1026.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1027.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1027.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1028.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1028.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1030.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1030.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1031.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1031.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1032.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1032.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_1033.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_1033.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_306_c_bio.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_306_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_307_c_bio.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_307_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/148/casestudy/www/layout/case_id_148_id_308_c_bio.html
+++ b/casestudies/148/casestudy/www/layout/case_id_148_id_308_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/15/casestudy/www/layout/case_id_15.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_158.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_158.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_159.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_159.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_160.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_160.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_161.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_161.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_162.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_162.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_163.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_163.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_164.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_164.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_165.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_165.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_166.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_166.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_167.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_167.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_168.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_168.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_170.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_170.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_20_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_20_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_21_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_21_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_221_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_221_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_222_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_222_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_223_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_223_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_224_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_224_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_225_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_225_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_226_c_photo.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_226_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_22_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_22_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_23_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_23_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_24_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_24_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/15/casestudy/www/layout/case_id_15_id_25_c_bio.html
+++ b/casestudies/15/casestudy/www/layout/case_id_15_id_25_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_172.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_172.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_173.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_173.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_174.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_174.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_175.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_175.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_176.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_176.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_177.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_177.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_179_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_179_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_180_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_180_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_181_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_181_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_182_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_182_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_183_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_183_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_184_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_184_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_185_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_185_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_186_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_186_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_187_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_187_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_188_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_188_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_189_pid_178.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_189_pid_178.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_190.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_190.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_191.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_191.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_192.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_192.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_193.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_193.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_194.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_194.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_195.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_195.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_232_c_photo.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_232_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_233_c_photo.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_233_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_234_c_photo.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_234_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_235_c_photo.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_235_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_27_c_bio.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_27_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_28_c_bio.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_28_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_29_c_bio.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_29_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/16/casestudy/www/layout/case_id_16_id_30_c_bio.html
+++ b/casestudies/16/casestudy/www/layout/case_id_16_id_30_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_197.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_197.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_198.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_198.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_199.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_199.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_200.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_200.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_201.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_201.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_202.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_202.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_203.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_203.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_204.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_204.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_205.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_205.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_31_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_31_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_32_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_32_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_33_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_33_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_34_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_34_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_35_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_35_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/17/casestudy/www/layout/case_id_17_id_36_c_bio.html
+++ b/casestudies/17/casestudy/www/layout/case_id_17_id_36_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18.html
@@ -60,6 +60,8 @@
     font-style:italic;
 }
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 <body>
   <div id="container">

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_207.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_207.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_208.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_208.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_209.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_209.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_210.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_210.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_211.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_211.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_212.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_212.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_213.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_213.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_37_c_bio.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_37_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_38_c_bio.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_38_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/18/casestudy/www/layout/case_id_18_id_39_c_bio.html
+++ b/casestudies/18/casestudy/www/layout/case_id_18_id_39_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/19/casestudy/www/layout/case_id_19.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_215.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_215.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_216.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_216.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_217.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_217.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_218.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_218.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_219.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_219.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_220.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_220.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_221.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_221.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_222.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_222.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_40_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_40_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_41_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_41_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_42_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_42_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_43_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_43_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_44_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_44_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_45_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_45_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_46_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_46_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/19/casestudy/www/layout/case_id_19_id_47_c_bio.html
+++ b/casestudies/19/casestudy/www/layout/case_id_19_id_47_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2.html
@@ -77,6 +77,8 @@ font-style:italic;
 }
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_15_c_bio.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_15_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_16_c_bio.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_16_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_17_c_bio.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_17_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_18_c_bio.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_18_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_19_c_bio.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_19_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_25_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_25_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_27_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_27_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_28_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_28_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_29_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_29_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_30_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_30_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_31_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_31_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_32_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_32_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_33_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_33_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_34_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_34_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_35_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_35_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_36_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_36_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_37_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_37_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_38_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_38_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_39_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_39_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_40_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_40_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_41_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_41_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_42_gid_1_c_video.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_42_gid_1_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_64.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_64.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_65.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_65.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_66.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_66.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_67.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_67.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_68.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_68.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_69.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_69.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_70.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_70.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_71.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_71.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_72.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_72.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_73.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_73.html
@@ -86,7 +86,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_74.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_74.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/2/casestudy/www/layout/case_id_2_id_75.html
+++ b/casestudies/2/casestudy/www/layout/case_id_2_id_75.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_224.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_224.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_225.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_225.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_226.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_226.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_227.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_227.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_228.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_228.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_228_c_photo.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_228_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_229.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_229.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_230.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_230.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_48_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_48_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_49_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_49_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_50_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_50_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_51_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_51_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_52_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_52_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_53_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_53_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_54_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_54_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/20/casestudy/www/layout/case_id_20_id_55_c_bio.html
+++ b/casestudies/20/casestudy/www/layout/case_id_20_id_55_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_232.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_232.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_233.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_233.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_234.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_234.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_235.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_235.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_236.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_236.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_237.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_237.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_238.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_238.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_239.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_239.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_240.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_240.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_241.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_241.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_242.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_242.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_56_c_bio.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_56_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_57_c_bio.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_57_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_61_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_61_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_62_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_62_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_63_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_63_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_64_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_64_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_65_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_65_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_66_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_66_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_67_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_67_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_68_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_68_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_69_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_69_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/21/casestudy/www/layout/case_id_21_id_71_gid_5_c_video.html
+++ b/casestudies/21/casestudy/www/layout/case_id_21_id_71_gid_5_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_244.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_244.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_245.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_245.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_246.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_246.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_247.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_247.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_248.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_248.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_249.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_249.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_250.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_250.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_251.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_251.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_252.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_252.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_253.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_253.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_254.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_254.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_255.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_255.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_256.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_256.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_257.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_257.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_258.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_258.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_259.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_259.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_260.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_260.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_62_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_62_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_63_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_63_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_64_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_64_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_65_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_65_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_66_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_66_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_67_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_67_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/22/casestudy/www/layout/case_id_22_id_68_c_bio.html
+++ b/casestudies/22/casestudy/www/layout/case_id_22_id_68_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_229_c_photo.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_229_c_photo.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_262.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_262.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_263.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_263.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_264.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_264.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_265.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_265.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_266.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_266.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_267.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_267.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_268.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_268.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_269.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_269.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_270.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_270.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_271.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_271.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_272.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_272.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_273.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_273.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_274.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_274.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_275.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_275.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_276.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_276.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_277.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_277.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_58_c_bio.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_58_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_59_c_bio.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_59_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_60_c_bio.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_60_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_61_c_bio.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_61_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_72_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_72_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_73_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_73_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_74_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_74_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_75_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_75_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_76_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_76_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_77_c_video.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_77_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/23/casestudy/www/layout/case_id_23_id_95_c_bio.html
+++ b/casestudies/23/casestudy/www/layout/case_id_23_id_95_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_100_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_100_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_101_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_101_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_102_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_102_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_103_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_103_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_104_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_104_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_105_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_105_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_106_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_106_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_107_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_107_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_108_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_108_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_109_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_109_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_110_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_110_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_111_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_111_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_112_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_112_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_113_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_113_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_114_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_114_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_115_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_115_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_116_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_116_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_117_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_117_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_88_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_88_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_89_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_89_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_90_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_90_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_92_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_92_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_93_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_93_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_94_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_94_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_95_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_95_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_96_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_96_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_97_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_97_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_98_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_98_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_99_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_gid_7_id_99_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_100_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_100_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_101_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_101_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_102_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_102_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_103_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_103_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_104_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_104_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_105_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_105_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_106_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_106_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_107_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_107_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_108_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_108_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_109_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_109_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_110_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_110_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_111_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_111_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_112_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_112_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_113_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_113_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_114_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_114_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_115_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_115_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_116_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_116_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_117_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_117_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_280.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_280.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_281.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_281.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_282.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_282.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_283.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_283.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_284.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_284.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_285.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_285.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_286.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_286.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_287.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_287.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_288.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_288.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_289.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_289.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_290.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_290.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_291.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_291.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_292.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_292.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_293.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_293.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_294.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_294.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_295.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_295.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_296.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_296.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_297.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_297.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_298.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_298.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_69_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_69_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_70_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_70_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_71_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_71_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_72_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_72_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_73_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_73_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_79_c_bio.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_79_c_bio.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_88_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_88_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_89_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_89_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_90_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_90_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_92_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_92_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_93_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_93_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_94_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_94_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_95_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_95_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_96_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_96_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_97_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_97_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_98_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_98_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/24/casestudy/www/layout/case_id_24_id_99_gid_7_c_video.html
+++ b/casestudies/24/casestudy/www/layout/case_id_24_id_99_gid_7_c_video.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_100_c_bio.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_100_c_bio.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_101_c_bio.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_101_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_102_c_bio.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_102_c_bio.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_103_c_bio.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_103_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_303.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_303.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_304.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_304.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_305.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_305.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_306.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_306.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_307.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_307.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_308.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_308.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_309.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_309.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_310.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_310.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_311.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_311.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_312.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_312.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_313.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_313.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/25/casestudy/www/layout/case_id_25_id_315.html
+++ b/casestudies/25/casestudy/www/layout/case_id_25_id_315.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/27/casestudy/www/layout/case_id_27.html
+++ b/casestudies/27/casestudy/www/layout/case_id_27.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/28/casestudy/www/layout/case_id_28.html
+++ b/casestudies/28/casestudy/www/layout/case_id_28.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_320.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_320.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_321.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_321.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_322.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_322.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_323.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_323.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_324.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_324.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_325.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_325.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_326.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_326.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_327.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_327.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_328.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_328.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_329.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_329.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_330.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_330.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_331.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_331.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_86_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_86_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_87_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_87_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_88_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_88_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_89_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_89_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_90_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_90_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_91_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_91_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_92_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_92_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_93_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_93_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/29/casestudy/www/layout/case_id_29_id_94_c_bio.html
+++ b/casestudies/29/casestudy/www/layout/case_id_29_id_94_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/30/casestudy/www/layout/case_id_30.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_333.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_333.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_334.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_334.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_336.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_336.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_337.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_337.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_339.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_339.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_340.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_340.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_341.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_341.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_342.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_342.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_343.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_343.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_344.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_344.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_345.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_345.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_346.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_346.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_347.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_347.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_348.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_348.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_349.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_349.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/30/casestudy/www/layout/case_id_30_id_96_c_bio.html
+++ b/casestudies/30/casestudy/www/layout/case_id_30_id_96_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_351.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_351.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_352.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_352.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_353.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_353.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_354.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_354.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_355.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_355.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_356.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_356.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_357.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_357.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_358.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_358.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_359.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_359.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_360.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_360.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_361.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_361.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_362.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_362.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_363.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_363.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_364.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_364.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_365.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_365.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_97_c_bio.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_97_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_98_c_bio.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_98_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/31/casestudy/www/layout/case_id_31_id_99_c_bio.html
+++ b/casestudies/31/casestudy/www/layout/case_id_31_id_99_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_105_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_105_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_106_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_106_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_107_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_107_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_108_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_108_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_109_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_109_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_110_c_bio.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_110_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_120_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_120_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_121_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_121_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_122_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_122_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_123_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_123_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_124_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_124_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_125_c_video.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_125_c_video.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_380.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_380.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_381.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_381.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_382.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_382.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/33/casestudy/www/layout/case_id_33_id_383.html
+++ b/casestudies/33/casestudy/www/layout/case_id_33_id_383.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_385_pid_384.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_385_pid_384.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_386.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_386.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_387_pid_386.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_387_pid_386.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_388_pid_386.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_388_pid_386.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_389_pid_386.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_389_pid_386.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_390.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_390.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_391_pid_390.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_391_pid_390.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_392.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_392.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_393_pid_392.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_393_pid_392.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_394_pid_392.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_394_pid_392.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_395_pid_392.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_395_pid_392.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_396_pid_392.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_396_pid_392.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_397.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_397.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_398_pid_397.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_398_pid_397.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_399_pid_397.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_399_pid_397.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_400_pid_397.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_400_pid_397.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_401.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_401.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_402_pid_401.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_402_pid_401.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_403.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_403.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_404_pid_403.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_404_pid_403.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_405_pid_403.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_405_pid_403.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_406.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_406.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_407_pid_406.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_407_pid_406.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_408.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_408.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_409_pid_408.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_409_pid_408.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_410_pid_408.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_410_pid_408.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_411_pid_408.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_411_pid_408.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_412.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_412.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_413_pid_412.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_413_pid_412.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_414_pid_412.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_414_pid_412.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/34/casestudy/www/layout/case_id_34_id_415_pid_412.html
+++ b/casestudies/34/casestudy/www/layout/case_id_34_id_415_pid_412.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/35/casestudy/www/layout/case_id_35.html
+++ b/casestudies/35/casestudy/www/layout/case_id_35.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/36/casestudy/www/layout/case_id_36.html
+++ b/casestudies/36/casestudy/www/layout/case_id_36.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37.html
@@ -68,6 +68,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_118_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_118_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_119_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_119_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_120_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_120_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_121_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_121_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_122_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_122_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_123_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_123_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_124_c_bio.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_124_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_456.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_456.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_457.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_457.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_458.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_458.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_459.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_459.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_460.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_460.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_461.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_461.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/37/casestudy/www/layout/case_id_37_id_462.html
+++ b/casestudies/37/casestudy/www/layout/case_id_37_id_462.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/38/casestudy/www/layout/case_id_38.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_111_c_bio.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_111_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_112_c_bio.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_112_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_422.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_422.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_423.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_423.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_424.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_424.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_425.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_425.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_426.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_426.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_427.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_427.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_428.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_428.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_429.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_429.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/38/casestudy/www/layout/case_id_38_id_453.html
+++ b/casestudies/38/casestudy/www/layout/case_id_38_id_453.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_113_c_bio.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_113_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_114_c_bio.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_114_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_431.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_431.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_432.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_432.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_433.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_433.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_434.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_434.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/39/casestudy/www/layout/case_id_39_id_454.html
+++ b/casestudies/39/casestudy/www/layout/case_id_39_id_454.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/40/casestudy/www/layout/case_id_40.html
+++ b/casestudies/40/casestudy/www/layout/case_id_40.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/40/casestudy/www/layout/case_id_40_id_115_c_bio.html
+++ b/casestudies/40/casestudy/www/layout/case_id_40_id_115_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/40/casestudy/www/layout/case_id_40_id_116_c_bio.html
+++ b/casestudies/40/casestudy/www/layout/case_id_40_id_116_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/40/casestudy/www/layout/case_id_40_id_117_c_bio.html
+++ b/casestudies/40/casestudy/www/layout/case_id_40_id_117_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_125_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_125_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_126_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_126_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_127_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_127_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_128_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_128_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_129_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_129_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_130_c_bio.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_130_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_466.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_466.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_467.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_467.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_468.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_468.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_469.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_469.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_470.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_470.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_471.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_471.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_472.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_472.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_473.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_473.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_474.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_474.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_475.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_475.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_476.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_476.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_477.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_477.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_478.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_478.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_479.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_479.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_499_pid_472.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_499_pid_472.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_500_pid_472.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_500_pid_472.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_501_pid_472.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_501_pid_472.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/43/casestudy/www/layout/case_id_43_id_502_pid_472.html
+++ b/casestudies/43/casestudy/www/layout/case_id_43_id_502_pid_472.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/49/casestudy/www/layout/case_id_49.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_481.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_481.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_482.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_482.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_483.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_483.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_484.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_484.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_485.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_485.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_486.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_486.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_487.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_487.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_488.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_488.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_489.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_489.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_490.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_490.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_491.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_491.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_492.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_492.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_493.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_493.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_494.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_494.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_495.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_495.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_496.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_496.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_497.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_497.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_498.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_498.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50.html
@@ -61,6 +61,8 @@
       font-style:italic;
     }
   </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_504.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_504.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_505.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_505.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_506.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_506.html
@@ -71,6 +71,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_507.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_507.html
@@ -74,6 +74,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_508.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_508.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_509.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_509.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_510.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_510.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_511.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_511.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_512.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_512.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_513.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_513.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_514.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_514.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_515.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_515.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_516.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_516.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_517.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_517.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_518.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_518.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_519.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_519.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_520.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_520.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_521.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_521.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51.html
@@ -74,6 +74,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_143_c_bio.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_143_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_144_c_bio.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_144_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_523.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_523.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_524.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_524.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_525.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_525.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_526.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_526.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_527.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_527.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_528.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_528.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_529.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_529.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_530.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_530.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_531.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_531.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_532.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_532.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/51/casestudy/www/layout/case_id_51_id_541.html
+++ b/casestudies/51/casestudy/www/layout/case_id_51_id_541.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53.html
@@ -75,6 +75,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_139_c_bio.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_139_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_140_c_bio.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_140_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_534.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_534.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_535.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_535.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_536.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_536.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_537.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_537.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_538.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_538.html
@@ -75,6 +75,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_539.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_539.html
@@ -76,6 +76,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/53/casestudy/www/layout/case_id_53_id_540.html
+++ b/casestudies/53/casestudy/www/layout/case_id_53_id_540.html
@@ -67,6 +67,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_141_c_bio.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_141_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_142_c_bio.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_142_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_543.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_543.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_544.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_544.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_545.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_545.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_547.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_547.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_548.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_548.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_549.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_549.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_550.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_550.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_551.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_551.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_552.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_552.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/54/casestudy/www/layout/case_id_54_id_553.html
+++ b/casestudies/54/casestudy/www/layout/case_id_54_id_553.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_145_c_bio.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_145_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_146_c_bio.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_146_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_147_c_bio.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_147_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_555.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_555.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_556.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_556.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_557.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_557.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_558.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_558.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_559.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_559.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_560.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_560.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_561.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_561.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/55/casestudy/www/layout/case_id_55_id_562.html
+++ b/casestudies/55/casestudy/www/layout/case_id_55_id_562.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_149_c_bio.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_149_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_150_c_bio.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_150_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_151_c_bio.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_151_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_152_c_bio.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_152_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_564.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_564.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_565.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_565.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_566.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_566.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_567.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_567.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_568.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_568.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_569.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_569.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_570.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_570.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/56/casestudy/www/layout/case_id_56_id_571.html
+++ b/casestudies/56/casestudy/www/layout/case_id_56_id_571.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/57/casestudy/www/layout/case_id_57.html
+++ b/casestudies/57/casestudy/www/layout/case_id_57.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_153_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_153_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_154_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_154_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_155_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_155_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_156_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_156_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_157_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_157_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_158_c_bio.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_158_c_bio.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_574.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_574.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_575.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_575.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_576.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_576.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_577.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_577.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_578.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_578.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_579.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_579.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_580.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_580.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_581.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_581.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_582.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_582.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/layout/case_id_59_id_583.html
+++ b/casestudies/59/casestudy/www/layout/case_id_59_id_583.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/59/casestudy/www/slideshows/Marine_with_photo_slideshow/index.html
+++ b/casestudies/59/casestudy/www/slideshows/Marine_with_photo_slideshow/index.html
@@ -8,6 +8,8 @@
       content="Associated Press Interactive: Death of a Marine: A photographer&#39;s journal">
 
 <script type="text/javascript" src="http://hosted.ap.org/specials/s_code_remote.js"></script>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 <body bgcolor="#000000">
 <center>

--- a/casestudies/60/casestudy/www/layout/case_id_60.html
+++ b/casestudies/60/casestudy/www/layout/case_id_60.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/61/casestudy/www/layout/case_id_61.html
+++ b/casestudies/61/casestudy/www/layout/case_id_61.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/62/casestudy/www/layout/case_id_62.html
+++ b/casestudies/62/casestudy/www/layout/case_id_62.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_159_c_bio.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_159_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_160_c_bio.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_160_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_161_c_bio.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_161_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_588.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_588.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_589.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_589.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_590.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_590.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_591.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_591.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_592.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_592.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_593.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_593.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_594.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_594.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_595.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_595.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/66/casestudy/www/layout/case_id_66_id_596.html
+++ b/casestudies/66/casestudy/www/layout/case_id_66_id_596.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_162_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_162_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_163_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_163_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_164_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_164_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_165_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_165_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_166_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_166_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_167_c_bio.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_167_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_598.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_598.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_599.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_599.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_601.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_601.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_602.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_602.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_603.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_603.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_604.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_604.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_605.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_605.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/67/casestudy/www/layout/case_id_67_id_610.html
+++ b/casestudies/67/casestudy/www/layout/case_id_67_id_610.html
@@ -86,7 +86,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/68/casestudy/www/layout/case_id_68.html
+++ b/casestudies/68/casestudy/www/layout/case_id_68.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_168_c_bio.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_168_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_169_c_bio.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_169_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_170_c_bio.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_170_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_613.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_613.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_614.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_614.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_615.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_615.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_616.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_616.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_617.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_617.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_618.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_618.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_619.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_619.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_620.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_620.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_621.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_621.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_622.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_622.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/69/casestudy/www/layout/case_id_69_id_623.html
+++ b/casestudies/69/casestudy/www/layout/case_id_69_id_623.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_171_c_bio.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_171_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_172_c_bio.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_172_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_173_c_bio.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_173_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_174_c_bio.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_174_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_175_c_bio.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_175_c_bio.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_625.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_625.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_626.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_626.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_627.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_627.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_628.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_628.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_629.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_629.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_630.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_630.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_631.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_631.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_632.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_632.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_633.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_633.html
@@ -87,7 +87,9 @@ font-style:italic;
 }
    </style>
   </meta>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_634.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_634.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/70/casestudy/www/layout/case_id_70_id_635.html
+++ b/casestudies/70/casestudy/www/layout/case_id_70_id_635.html
@@ -80,6 +80,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_176_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_176_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_177_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_177_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_178_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_178_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_179_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_179_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_180_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_180_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_181_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_181_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_182_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_182_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_183_c_bio.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_183_c_bio.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_637.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_637.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_638.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_638.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_639.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_639.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_640.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_640.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_641.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_641.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_642.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_642.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_643.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_643.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/83/casestudy/www/layout/case_id_83_id_644.html
+++ b/casestudies/83/casestudy/www/layout/case_id_83_id_644.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/84/casestudy/www/layout/case_id_84.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_646.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_646.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_647.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_647.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_648.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_648.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_649.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_649.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_650.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_650.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_651.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_651.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_652.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_652.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_655.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_655.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/84/casestudy/www/layout/case_id_84_id_656.html
+++ b/casestudies/84/casestudy/www/layout/case_id_84_id_656.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_184_c_bio.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_184_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_658.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_658.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_659.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_659.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_660.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_660.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_661.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_661.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_662.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_662.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_663.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_663.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_664.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_664.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_665.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_665.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/85/casestudy/www/layout/case_id_85_id_666.html
+++ b/casestudies/85/casestudy/www/layout/case_id_85_id_666.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/86/casestudy/www/layout/case_id_86.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_185_c_bio.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_185_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_186_c_bio.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_186_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_187_c_bio.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_187_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_668.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_668.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_669.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_669.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_670.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_670.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_671.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_671.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_672.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_672.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_673.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_673.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_674.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_674.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/86/casestudy/www/layout/case_id_86_id_675.html
+++ b/casestudies/86/casestudy/www/layout/case_id_86_id_675.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_201_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_201_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_202_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_202_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_203_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_203_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_204_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_204_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_205_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_205_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_206_c_bio.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_206_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_688.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_688.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_689.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_689.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_690.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_690.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_691.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_691.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_692.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_692.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_693.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_693.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_694.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_694.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_695.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_695.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_696.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_696.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/87/casestudy/www/layout/case_id_87_id_697.html
+++ b/casestudies/87/casestudy/www/layout/case_id_87_id_697.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/9/casestudy/www/layout/case_id_9.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_100_pid_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_100_pid_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_101_pid_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_101_pid_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_102_pid_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_102_pid_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_103_pid_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_103_pid_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_104_pid_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_104_pid_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_105_pid_96.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_105_pid_96.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_106_pid_96.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_106_pid_96.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_107_pid_96.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_107_pid_96.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_108_pid_97.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_108_pid_97.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_109_pid_97.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_109_pid_97.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_79.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_79.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_80.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_80.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_81_pid_78.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_81_pid_78.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_82_pid_78.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_82_pid_78.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_83.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_83.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_85_pid_78.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_85_pid_78.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_86_pid_79.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_86_pid_79.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_87_pid_79.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_87_pid_79.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_88_pid_79.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_88_pid_79.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_89_pid_80.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_89_pid_80.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_90_pid_80.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_90_pid_80.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_91_pid_80.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_91_pid_80.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_92_pid_83.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_92_pid_83.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_93_pid_83.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_93_pid_83.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_94.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_94.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_95.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_95.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_96.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_96.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_97.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_97.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_98_pid_94.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_98_pid_94.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/9/casestudy/www/layout/case_id_9_id_99_pid_94.html
+++ b/casestudies/9/casestudy/www/layout/case_id_9_id_99_pid_94.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_191_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_191_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_192_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_192_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_193_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_193_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_194_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_194_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_195_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_195_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_196_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_196_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_197_c_bio.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_197_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_677.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_677.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_678.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_678.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_679.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_679.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_680.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_680.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_681.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_681.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_682.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_682.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_683.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_683.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_684.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_684.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_685.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_685.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/90/casestudy/www/layout/case_id_90_id_686.html
+++ b/casestudies/90/casestudy/www/layout/case_id_90_id_686.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_198_c_bio.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_198_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_199_c_bio.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_199_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_200_c_bio.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_200_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_699.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_699.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_700.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_700.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_701.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_701.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_702.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_702.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_703.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_703.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_704.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_704.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_705.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_705.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_706.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_706.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_707.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_707.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/91/casestudy/www/layout/case_id_91_id_708.html
+++ b/casestudies/91/casestudy/www/layout/case_id_91_id_708.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_207_c_bio.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_207_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_208_c_bio.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_208_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_209_c_bio.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_209_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_210_c_bio.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_210_c_bio.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_710.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_710.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_711.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_711.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_712.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_712.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_714.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_714.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_715.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_715.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_716.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_716.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_717.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_717.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_718.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_718.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_719.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_719.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_720.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_720.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_721.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_721.html
@@ -85,7 +85,9 @@
 font-style:italic;
 }
   </style>
- </head>
+ <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+</head>
  <body>
   <div id="container">
    <!-- Banner header -->

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_722.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_722.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_723.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_723.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_724.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_724.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_725.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_725.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/92/casestudy/www/layout/case_id_92_id_726.html
+++ b/casestudies/92/casestudy/www/layout/case_id_92_id_726.html
@@ -78,6 +78,8 @@ font-style:italic;
 
 
 </style>
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>

--- a/casestudies/index.html
+++ b/casestudies/index.html
@@ -9,6 +9,8 @@
 <!-- Optional theme -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 
+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Done with the following find command:
```
find . -name "*.html" -exec sed -i 's+</head>+<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />\n<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>\n</head>+' {} +
```

https://stackoverflow.com/a/47815249/173630