### PR TITLE
Replace embedded videos

### DIFF
--- a/casestudies/49/casestudy/www/layout/case_id_49_id_482.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_482.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Paul Schaefer | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Paul Schaefer | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,349 +84,357 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Paul Schaefer</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Paul Schaefer</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Members of the CONTACTO team were already familiar with the broad outlines of Schaefer&rsquo;s unusual personal story, but they had to remind themselves of the details. Schaefer, the news team learned, was born in 1921 near the Dutch border in Troisdorf,  Germany. </span>At the start of WWII, Schaefer became a medic and served out the war in occupied France.</p>
-<p><span>An evangelical Christian, Schaefer worked briefly as a youth leader for a church, but was fired on suspicion that he had abused some of the boys in his care. So Schaefer took to the road as a minister. He had considerable charisma, and within a few years had attracted several hundred followers and set up a religious commune for war widows and orphans at Siegburg, near Bonn.</span></p>
-<p><span>In the early 1960s, however, two mothers complained to the German authorities that Schaefer was sexually abusing their sons. Schaefer fled before he could be arrested. His final destination: Chile, where he arrived in 1964 with several hundred men, women, and children who believed in Schaefer and a vision he advertised of an ideal German community. </span></p>
-<p><i><b><span>Colonia Dignidad.</span></b><span> </span></i><span>At <i>Colonia Dignidad</i>, Schaefer recreated a fantasy version of the German village of his youth. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/128/005_fuentes_setup_colonia.flv&amp;autostart=false " allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Residents retained their German citizenship, wore traditional German clothing and everyone, including Chilean children adopted from neighboring communities, spoke German.<a href="case_id_49_id_482.html#_ftn1" name="_ftnref1" title=""><span>[1]</span></a></span> <i>Colonia Dignidad</i>, on 33,000 acres, became a state within a state.<a href="case_id_49_id_482.html#_ftn2" name="_ftnref2" title=""><span>[2]</span></a> Residents, who had to confess their sins to Schaefer daily, were not allowed outside the <i>Colonia</i>, where they worked long hours without compensation. They owed complete fealty to Schaefer, who regularly sexually abused the young boys living in the colony.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/129/004_fuentes_mechanism_sex_abuse.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<div><br clear="all" />
-<hr width="33%" size="1" align="left" />
-<div id="ftn1">
-<p><span style="font-size: smaller;"><a href="case_id_49_id_482.html#_ftnref1" name="_ftn1" title="">[1]</a> Shirley Christian, </span><a class="extlink" target="_blank" href="http://www.nytimes.com/1988/03/26/world/santiago-journal-at-a-chilean-utopia-dark-tales-of-dread-doings.html?scp=1&amp;sq=At%20a%20Chilean%20%E2%80%98Utopia,%E2%80%99%20Dark%20Tales%20of%20Dread%20Doing&amp;st=cse"><span style="font-size: smaller;">&ldquo;Santiago Journal: At a Chilean &lsquo;Utopia,&rsquo; Dark Tales of Dread Doing,&rdquo;</span></a><span style="font-size: smaller;"> <i>New York Times</i>, March 26, 1988.</span></p>
-</div>
-<div id="ftn2">
-<p><a href="case_id_49_id_482.html#_ftnref2" name="_ftn2" title=""></a><span style="font-size: smaller;"><a href="case_id_49_id_482.html#_ftnref2" name="_ftn2" title="">[2]</a> &ldquo;Rights group seeks protection for secret Chilean enclave,&rdquo; <i>Agence France Presse</i>, September 19, 1997.</span></p>
-</div>
-</div></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_481.html" class="page-previous" title="Go to previous page">&#171;&#160;Introduction</a>
-
-<a href="case_id_49_id_483.html" class="page-next" title="Go to next page">Schaefer and the Chilean Authorities&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Paul Schaefer
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Paul Schaefer
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Members of the CONTACTO team were already familiar with the broad outlines of Schaefer’s unusual personal story, but they had to remind themselves of the details. Schaefer, the news team learned, was born in 1921 near the Dutch border in Troisdorf,  Germany.
+         </span>
+         At the start of WWII, Schaefer became a medic and served out the war in occupied France.
+        </p>
+        <p>
+         <span>
+          An evangelical Christian, Schaefer worked briefly as a youth leader for a church, but was fired on suspicion that he had abused some of the boys in his care. So Schaefer took to the road as a minister. He had considerable charisma, and within a few years had attracted several hundred followers and set up a religious commune for war widows and orphans at Siegburg, near Bonn.
+         </span>
+        </p>
+        <p>
+         <span>
+          In the early 1960s, however, two mothers complained to the German authorities that Schaefer was sexually abusing their sons. Schaefer fled before he could be arrested. His final destination: Chile, where he arrived in 1964 with several hundred men, women, and children who believed in Schaefer and a vision he advertised of an ideal German community.
+         </span>
+        </p>
+        <p>
+         <i>
+          <b>
+           <span>
+            Colonia Dignidad.
+           </span>
+          </b>
+          <span>
+          </span>
+         </i>
+         <span>
+          At
+          <i>
+           Colonia Dignidad
+          </i>
+          , Schaefer recreated a fantasy version of the German village of his youth.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/128/005_fuentes_setup_colonia.flv&amp;autostart=false " height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/OAb5FzKTH50?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Residents retained their German citizenship, wore traditional German clothing and everyone, including Chilean children adopted from neighboring communities, spoke German.
+          <a href="case_id_49_id_482.html#_ftn1" name="_ftnref1" title="">
+           <span>
+            [1]
+           </span>
+          </a>
+         </span>
+         <i>
+          Colonia Dignidad
+         </i>
+         , on 33,000 acres, became a state within a state.
+         <a href="case_id_49_id_482.html#_ftn2" name="_ftnref2" title="">
+          <span>
+           [2]
+          </span>
+         </a>
+         Residents, who had to confess their sins to Schaefer daily, were not allowed outside the
+         <i>
+          Colonia
+         </i>
+         , where they worked long hours without compensation. They owed complete fealty to Schaefer, who regularly sexually abused the young boys living in the colony.
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/129/004_fuentes_mechanism_sex_abuse.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/FD0tQh2zlHg?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <div>
+         <br clear="all"/>
+         <hr align="left" size="1" width="33%"/>
+         <div id="ftn1">
+          <p>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_482.html#_ftnref1" name="_ftn1" title="">
+             [1]
+            </a>
+            Shirley Christian,
+           </span>
+           <a class="extlink" href="http://www.nytimes.com/1988/03/26/world/santiago-journal-at-a-chilean-utopia-dark-tales-of-dread-doings.html?scp=1&amp;sq=At%20a%20Chilean%20%E2%80%98Utopia,%E2%80%99%20Dark%20Tales%20of%20Dread%20Doing&amp;st=cse" target="_blank">
+            <span style="font-size: smaller;">
+             “Santiago Journal: At a Chilean ‘Utopia,’ Dark Tales of Dread Doing,”
+            </span>
+           </a>
+           <span style="font-size: smaller;">
+            <i>
+             New York Times
+            </i>
+            , March 26, 1988.
+           </span>
+          </p>
+         </div>
+         <div id="ftn2">
+          <p>
+           <a href="case_id_49_id_482.html#_ftnref2" name="_ftn2" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_482.html#_ftnref2" name="_ftn2" title="">
+             [2]
+            </a>
+            “Rights group seeks protection for secret Chilean enclave,”
+            <i>
+             Agence France Presse
+            </i>
+            , September 19, 1997.
+           </span>
+          </p>
+         </div>
+        </div>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_481.html" title="Go to previous page">
+          « Introduction
+         </a>
+         <a class="page-next" href="case_id_49_id_483.html" title="Go to next page">
+          Schaefer and the Chilean Authorities »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_483.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_483.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Schaefer and the Chilean Authorities | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Schaefer and the Chilean Authorities | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,358 +84,464 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Schaefer and the Chilean Authorities</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Schaefer and the Chilean Authorities</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p>Schaefer and his deputies<span>, many of whom had served in the Waffen-SS and Gestapo during World War II,</span> set up an elaborate security system: a network of tunnels and bunkers, watchtowers, guard stations, vicious watchdogs, and military training for the <i>Colonia</i>&rsquo;s men, each of whom carried a sidearm.<span> <i>Colonia Dignidad</i> also had its own airport and airplanes, internal telephone system, power plant, brick factory, and a chemical-weapons laboratory.<a title="" name="_ftnref1" href="case_id_49_id_483.html#_ftn1"><span>[1]</span></a></span></p>
-<p><span>The public knew little about the <i>Colonia</i>, which became quite prosperous through sales of bread, vegetables, and cheese in the community. Interest was piqued in the late 1960s, when details began to trickle out of the closed compound (one resident escaped in 1966 on his third attempt). But Schaefer had protection beyond his security system. He cultivated relationships with the authorities, showered them with gifts and sponsored charitable projects. Media were rarely allowed into <i>Colonia Dignidad</i>. When they were, journalists were treated to a highly choreographed image of wholesomeness.</span></p>
-<p><span>Schaefer&rsquo;s most powerful protector was his good friend, Augusto Pinochet, who seized power in Chile on September 11, 1973, and set up an authoritarian military dictatorship. Pinochet&rsquo;s regime rounded up thousands of Chileans on suspicion of opposition; many were tortured and killed. <i>Colonia Dignidad</i> was one place Pinochet could count on for cooperation.<a title="" name="_ftnref2" href="case_id_49_id_483.html#_ftn2"><span>[2]</span></a></span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/130/009_fuentes_hospital_torture.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>By the late 1980s, Schaefer had freely abused minors within the <i>Colonia</i> for over 20 years. Under the guise of a charitable program for local youth, he even extended his reach into the surrounding community.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/131/010_fuentes_schaefer_abuse_chilean_children.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><b><i><span>Schaefer&rsquo;s flight</span></i><span>. </span></b><span>But when Pinochet in 1990 was replaced by a democratic government, Schaefer&rsquo;s protection network suffered a major blow. Pinochet&rsquo;s successor, Patricio Aylwin, in 1992 revoked the <i>Colonia</i>&rsquo;s status as a non-profit after Schaefer was charged with tax evasion. Then in 1997, two young colonists escaped. They claimed Schaefer had abused them, as well as children as young as eight.<a title="" name="_ftnref3" href="case_id_49_id_483.html#_ftn3"><span>[3]</span></a></span> In May 1997, Judge Hern&aacute;n Gonzalez issued an arrest warrant for Schaefer as well as 10 deputies in relation to some 40 investigations.<a title="" name="_ftnref4" href="case_id_49_id_483.html#_ftn4"><span>[4]</span></a> Chilean and Interpol police went to the <i>Colonia</i> to arrest him, but Schaefer had vanished.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/132/012_rodriguez_schaefer_escape.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p>
-<p><span>Schaefer was gone, but his hold on the Chilean imagination only grew with the years. What, Chileans wondered, had really gone on inside <i>Colonia Dignidad</i>? How had Schaefer kept hundreds of people enslaved? Was it true that Nazi fugitives like Joseph Mengele had hidden and undergone plastic surgery at <i>Colonia Dignidad</i>? How had such voracious pedophilia gone unpunished for decades? Who had helped him escape? Where was he now? </span></p>
-<div><br clear="all" />
-<hr width="33%" size="1" align="left" />
-<div id="ftn1">
-<p><span style="font-size: smaller;"><a title="" name="_ftn1" href="case_id_49_id_483.html#_ftnref1">[1]</a>      Charles A. Krause, &ldquo;Colonia Dignidad: Nobody Comes Goes. Mystery Veils Colony in Chile,&rdquo; <i>Washington</i><i> Post</i>, February 11, 1980.</span></p>
-</div>
-<div id="ftn2">
-<p><a title="" name="_ftn2" href="case_id_49_id_483.html#_ftnref2"></a><span style="font-size: smaller;"><a title="" name="_ftn2" href="case_id_49_id_483.html#_ftnref2">[2]</a>      &ldquo;57<sup>th</sup> lawsuit filed against Pinochet in Chile,&rdquo; <i>Agence France Presse</i>, January 18, 2000; Larry Rohter, </span><a href="http://www.nytimes.com/2002/05/19/ international/americas/19CHIL.html?pagewanted=all&amp;position=bottom" target="_blank" class="extlink"><span style="font-size: smaller;">&ldquo;Chilean Mystery: Clues to Vanished American,&rdquo;</span></a><span style="font-size: smaller;"> <i>New York Times, </i>May 19, 2002. In 1977, Amnesty International released a report alleging that <i>Colonia Dignidad</i> was a base of operations for DINA, the Chilean secret police. (Schaefer was also close friends with General Miguel Contreras, who ran DINA.) Schaefer sued Amnesty International for libel and blocked a West German investigative delegation from entering the colony. Gustavo Gonzalez, &ldquo;Chile-Politics: Net tightens on shady settlement,&rdquo; <i>IPS-Inter Press Service</i>, April 11, 1997.</span></p>
-</div>
-<div id="ftn3">
-<p><a title="" name="_ftn3" href="case_id_49_id_483.html#_ftnref3"></a><span style="font-size: smaller;"><a title="" name="_ftn3" href="case_id_49_id_483.html#_ftnref3">[3]</a>      &ldquo;Two youths in Frankfurt after escaping Colonia Dignidad,&rdquo; <i>Agence France Presse</i>, August 2, 1997.</span></p>
-</div>
-<div id="ftn4">
-<p><a title="" name="_ftn4" href="case_id_49_id_483.html#_ftnref4"></a><span style="font-size: smaller;"><a title="" name="_ftn4" href="case_id_49_id_483.html#_ftnref4">[4]</a>      &ldquo;Chilean judge orders arrest of leaders of former Nazi enclave,&rdquo; <i>Agence France Presse</i>, May 10, 1997.</span></p>
-</div>
-</div></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_482.html" class="page-previous" title="Go to previous page">&#171;&#160;Paul Schaefer</a>
-
-<a href="case_id_49_id_484.html" class="page-next" title="Go to next page">CONTACTO&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Schaefer and the Chilean Authorities
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Schaefer and the Chilean Authorities
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         Schaefer and his deputies
+         <span>
+          , many of whom had served in the Waffen-SS and Gestapo during World War II,
+         </span>
+         set up an elaborate security system: a network of tunnels and bunkers, watchtowers, guard stations, vicious watchdogs, and military training for the
+         <i>
+          Colonia
+         </i>
+         ’s men, each of whom carried a sidearm.
+         <span>
+          <i>
+           Colonia Dignidad
+          </i>
+          also had its own airport and airplanes, internal telephone system, power plant, brick factory, and a chemical-weapons laboratory.
+          <a href="case_id_49_id_483.html#_ftn1" name="_ftnref1" title="">
+           <span>
+            [1]
+           </span>
+          </a>
+         </span>
+        </p>
+        <p>
+         <span>
+          The public knew little about the
+          <i>
+           Colonia
+          </i>
+          , which became quite prosperous through sales of bread, vegetables, and cheese in the community. Interest was piqued in the late 1960s, when details began to trickle out of the closed compound (one resident escaped in 1966 on his third attempt). But Schaefer had protection beyond his security system. He cultivated relationships with the authorities, showered them with gifts and sponsored charitable projects. Media were rarely allowed into
+          <i>
+           Colonia Dignidad
+          </i>
+          . When they were, journalists were treated to a highly choreographed image of wholesomeness.
+         </span>
+        </p>
+        <p>
+         <span>
+          Schaefer’s most powerful protector was his good friend, Augusto Pinochet, who seized power in Chile on September 11, 1973, and set up an authoritarian military dictatorship. Pinochet’s regime rounded up thousands of Chileans on suspicion of opposition; many were tortured and killed.
+          <i>
+           Colonia Dignidad
+          </i>
+          was one place Pinochet could count on for cooperation.
+          <a href="case_id_49_id_483.html#_ftn2" name="_ftnref2" title="">
+           <span>
+            [2]
+           </span>
+          </a>
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/130/009_fuentes_hospital_torture.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" title="YouTube video player" src="https://www.youtube.com/embed/jIk8qlNBe0k?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          By the late 1980s, Schaefer had freely abused minors within the
+          <i>
+           Colonia
+          </i>
+          for over 20 years. Under the guise of a charitable program for local youth, he even extended his reach into the surrounding community.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/131/010_fuentes_schaefer_abuse_chilean_children.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/pMBzvt3pHkE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           <span>
+            Schaefer’s flight
+           </span>
+          </i>
+          <span>
+           .
+          </span>
+         </b>
+         <span>
+          But when Pinochet in 1990 was replaced by a democratic government, Schaefer’s protection network suffered a major blow. Pinochet’s successor, Patricio Aylwin, in 1992 revoked the
+          <i>
+           Colonia
+          </i>
+          ’s status as a non-profit after Schaefer was charged with tax evasion. Then in 1997, two young colonists escaped. They claimed Schaefer had abused them, as well as children as young as eight.
+          <a href="case_id_49_id_483.html#_ftn3" name="_ftnref3" title="">
+           <span>
+            [3]
+           </span>
+          </a>
+         </span>
+         In May 1997, Judge Hernán Gonzalez issued an arrest warrant for Schaefer as well as 10 deputies in relation to some 40 investigations.
+         <a href="case_id_49_id_483.html#_ftn4" name="_ftnref4" title="">
+          <span>
+           [4]
+          </span>
+         </a>
+         Chilean and Interpol police went to the
+         <i>
+          Colonia
+         </i>
+         to arrest him, but Schaefer had vanished.
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/132/012_rodriguez_schaefer_escape.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/egLmRay4gOc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          Schaefer was gone, but his hold on the Chilean imagination only grew with the years. What, Chileans wondered, had really gone on inside
+          <i>
+           Colonia Dignidad
+          </i>
+          ? How had Schaefer kept hundreds of people enslaved? Was it true that Nazi fugitives like Joseph Mengele had hidden and undergone plastic surgery at
+          <i>
+           Colonia Dignidad
+          </i>
+          ? How had such voracious pedophilia gone unpunished for decades? Who had helped him escape? Where was he now?
+         </span>
+        </p>
+        <div>
+         <br clear="all"/>
+         <hr align="left" size="1" width="33%"/>
+         <div id="ftn1">
+          <p>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_483.html#_ftnref1" name="_ftn1" title="">
+             [1]
+            </a>
+            Charles A. Krause, “Colonia Dignidad: Nobody Comes Goes. Mystery Veils Colony in Chile,”
+            <i>
+             Washington
+            </i>
+            <i>
+             Post
+            </i>
+            , February 11, 1980.
+           </span>
+          </p>
+         </div>
+         <div id="ftn2">
+          <p>
+           <a href="case_id_49_id_483.html#_ftnref2" name="_ftn2" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_483.html#_ftnref2" name="_ftn2" title="">
+             [2]
+            </a>
+            “57
+            <sup>
+             th
+            </sup>
+            lawsuit filed against Pinochet in Chile,”
+            <i>
+             Agence France Presse
+            </i>
+            , January 18, 2000; Larry Rohter,
+           </span>
+           <a class="extlink" href="http://www.nytimes.com/2002/05/19/ international/americas/19CHIL.html?pagewanted=all&amp;position=bottom" target="_blank">
+            <span style="font-size: smaller;">
+             “Chilean Mystery: Clues to Vanished American,”
+            </span>
+           </a>
+           <span style="font-size: smaller;">
+            <i>
+             New York Times,
+            </i>
+            May 19, 2002. In 1977, Amnesty International released a report alleging that
+            <i>
+             Colonia Dignidad
+            </i>
+            was a base of operations for DINA, the Chilean secret police. (Schaefer was also close friends with General Miguel Contreras, who ran DINA.) Schaefer sued Amnesty International for libel and blocked a West German investigative delegation from entering the colony. Gustavo Gonzalez, “Chile-Politics: Net tightens on shady settlement,”
+            <i>
+             IPS-Inter Press Service
+            </i>
+            , April 11, 1997.
+           </span>
+          </p>
+         </div>
+         <div id="ftn3">
+          <p>
+           <a href="case_id_49_id_483.html#_ftnref3" name="_ftn3" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_483.html#_ftnref3" name="_ftn3" title="">
+             [3]
+            </a>
+            “Two youths in Frankfurt after escaping Colonia Dignidad,”
+            <i>
+             Agence France Presse
+            </i>
+            , August 2, 1997.
+           </span>
+          </p>
+         </div>
+         <div id="ftn4">
+          <p>
+           <a href="case_id_49_id_483.html#_ftnref4" name="_ftn4" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_49_id_483.html#_ftnref4" name="_ftn4" title="">
+             [4]
+            </a>
+            “Chilean judge orders arrest of leaders of former Nazi enclave,”
+            <i>
+             Agence France Presse
+            </i>
+            , May 10, 1997.
+           </span>
+          </p>
+         </div>
+        </div>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_482.html" title="Go to previous page">
+          « Paul Schaefer
+         </a>
+         <a class="page-next" href="case_id_49_id_484.html" title="Go to next page">
+          CONTACTO »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_484.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_484.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>CONTACTO | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   CONTACTO | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,340 +84,318 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>CONTACTO</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">CONTACTO</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>In December 2003&mdash;six years after he disappeared&mdash;a reporter at the investigative television documentary program CONTACTO was offered a tantalizing lead in the Schaefer case. CONTACTO was one of the first fruits of democracy in Chile. Founded in 1991, CONTACTO was a prime-time program dedicated to investigative television reporting both in Chile and abroad. It was broadcast on <a href="http://contacto.canal13.cl/contacto2/html/" target="_blank" class="extlink">Channel 13,</a> and affiliated with the Universidad Cat&oacute;lica. </span></p>
-<p><span>Its small team of 12 producers and reporters had investigated complex sociological and human-interest stories, including segments on child abuse, drug trafficking, post-Cold War Berlin, missionaries in Africa, Parkinson&rsquo;s disease, and the poor&rsquo;s lack of access to the judicial system. A story on foreign pedophiles who fled to Chile and lived there with impunity had brought about a change in legislation. All of this earned CONTACTO a reputation for serious and in-depth journalism, as well as many awards for its work. </span></p>
-<p><b><i>A tip</i><span>.</span></b><span> In December 2003 Carola Fuentes, an investigative reporter at CONTACTO, received a phone call. Hern&aacute;n Fernandez was the lawyer for Schaefer&rsquo;s victims, and someone well known to CONTACTO. Over the years, he had provided a wealth of information about the <i>Colonia</i>, as well as contacts with surviving members. Now he had a tip from an anonymous source about Schaefer&rsquo;s whereabouts, and wanted to pass the tip on to CONTACTO. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/133/019_fuentes_journalist_joke_call.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Fuentes was interested, but knew she would need more information. Nonetheless, she took the lead to her executive editor. Patricia Baz&aacute;n Cardemil was intrigued, but skeptical. The lead was so tenuous that she was wary of sending a reporter on what could easily prove a wild-goose chase. On the other hand, she knew that Fernandez, at least, was a sterling source. </span></p>
-<p><span>Even if the search proved futile, Baz&aacute;n Cardemil reasoned, it might be worth the risk. Schaefer had become such a mythical and reviled figure in Chilean society that, if Fuentes managed to find him, audiences would be riveted. Baz&aacute;n Cardemil gave Fuentes the green light to pursue the story. Her editor would be Pilar Rodr&iacute;guez<span>.</span></span></p>
-<p><b><i><span>First steps</span></i><span>.</span></b><span> Through Fernandez, Fuentes first interviewed two ex<i>-colonos</i>. She realized that while they did not know Schaefer&rsquo;s exact location, they did have a lot of useful information. They knew, for example, that Schaefer was incapable of living alone. Old and sick, wherever he was he was likely surrounded by a protective phalanx of caretakers. The couple provided names of several of Schaefer&rsquo;s most trusted deputies, all of whom had disappeared at the same time as Schaefer. Among them were an elderly nurse, a cook, Schaefer&rsquo;s adopted daughter, and a security specialist named Peter Schmidt. </span></p>
-<p><span>They warned that Schmidt, Schaefer&rsquo;s right-hand man and bodyguard, was a dangerous man. Trained in karate and marksmanship, Schmidt had grown up at Schaefer&rsquo;s side, and his loyalty was unconditional. Fuentes realized that this was her first tangible lead: find Peter Schmidt or the rest of Schaefer&rsquo;s inner circle, and she might find Paul Schaefer. </span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_483.html" class="page-previous" title="Go to previous page">&#171;&#160;Schaefer and the Chilean Authorities</a>
-
-<a href="case_id_49_id_485.html" class="page-next" title="Go to next page">Leads to Argentina&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          CONTACTO
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       CONTACTO
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          In December 2003—six years after he disappeared—a reporter at the investigative television documentary program CONTACTO was offered a tantalizing lead in the Schaefer case. CONTACTO was one of the first fruits of democracy in Chile. Founded in 1991, CONTACTO was a prime-time program dedicated to investigative television reporting both in Chile and abroad. It was broadcast on
+          <a class="extlink" href="http://contacto.canal13.cl/contacto2/html/" target="_blank">
+           Channel 13,
+          </a>
+          and affiliated with the Universidad Católica.
+         </span>
+        </p>
+        <p>
+         <span>
+          Its small team of 12 producers and reporters had investigated complex sociological and human-interest stories, including segments on child abuse, drug trafficking, post-Cold War Berlin, missionaries in Africa, Parkinson’s disease, and the poor’s lack of access to the judicial system. A story on foreign pedophiles who fled to Chile and lived there with impunity had brought about a change in legislation. All of this earned CONTACTO a reputation for serious and in-depth journalism, as well as many awards for its work.
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           A tip
+          </i>
+          <span>
+           .
+          </span>
+         </b>
+         <span>
+          In December 2003 Carola Fuentes, an investigative reporter at CONTACTO, received a phone call. Hernán Fernandez was the lawyer for Schaefer’s victims, and someone well known to CONTACTO. Over the years, he had provided a wealth of information about the
+          <i>
+           Colonia
+          </i>
+          , as well as contacts with surviving members. Now he had a tip from an anonymous source about Schaefer’s whereabouts, and wanted to pass the tip on to CONTACTO.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/133/019_fuentes_journalist_joke_call.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/6OW6g76GxHI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Fuentes was interested, but knew she would need more information. Nonetheless, she took the lead to her executive editor. Patricia Bazán Cardemil was intrigued, but skeptical. The lead was so tenuous that she was wary of sending a reporter on what could easily prove a wild-goose chase. On the other hand, she knew that Fernandez, at least, was a sterling source.
+         </span>
+        </p>
+        <p>
+         <span>
+          Even if the search proved futile, Bazán Cardemil reasoned, it might be worth the risk. Schaefer had become such a mythical and reviled figure in Chilean society that, if Fuentes managed to find him, audiences would be riveted. Bazán Cardemil gave Fuentes the green light to pursue the story. Her editor would be Pilar Rodríguez
+          <span>
+           .
+          </span>
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           <span>
+            First steps
+           </span>
+          </i>
+          <span>
+           .
+          </span>
+         </b>
+         <span>
+          Through Fernandez, Fuentes first interviewed two ex
+          <i>
+           -colonos
+          </i>
+          . She realized that while they did not know Schaefer’s exact location, they did have a lot of useful information. They knew, for example, that Schaefer was incapable of living alone. Old and sick, wherever he was he was likely surrounded by a protective phalanx of caretakers. The couple provided names of several of Schaefer’s most trusted deputies, all of whom had disappeared at the same time as Schaefer. Among them were an elderly nurse, a cook, Schaefer’s adopted daughter, and a security specialist named Peter Schmidt.
+         </span>
+        </p>
+        <p>
+         <span>
+          They warned that Schmidt, Schaefer’s right-hand man and bodyguard, was a dangerous man. Trained in karate and marksmanship, Schmidt had grown up at Schaefer’s side, and his loyalty was unconditional. Fuentes realized that this was her first tangible lead: find Peter Schmidt or the rest of Schaefer’s inner circle, and she might find Paul Schaefer.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_483.html" title="Go to previous page">
+          « Schaefer and the Chilean Authorities
+         </a>
+         <a class="page-next" href="case_id_49_id_485.html" title="Go to next page">
+          Leads to Argentina »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_485.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_485.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Leads to Argentina | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Leads to Argentina | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,336 +84,273 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Leads to Argentina</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Leads to Argentina</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Fuentes soon obtained a second piece of evidence that suggested Schaefer might be in Argentina: the names of three of Schaefer&rsquo;s inner circle&mdash;Peter Schmidt, Renate Freitag, and Friedhelm Zeitner&mdash;appeared on a log of ferry departures from Argentina to Uruguay. With this second mention of Argentina, Fuentes was persuaded: it was time to take a look for herself. So in mid-January 2004, she approached Editor </span>Rodr&iacute;guez<span> to propose a trip to Buenos Aires. Because the flight was inexpensive, </span>Rodr&iacute;guez<span> said yes. With the log and a photo of Schmidt as her only clues, Fuentes and a cameraman traveled to Buenos Aires. </span></p>
-<p><span>By analyzing the dates in the travel log, they determined that Schmidt and the others were traveling to Uruguay every three months, most likely to renew their tourist visas. Excited to find that their arrival in Argentina coincided with the date of the Schaefer associates&rsquo; next probable trip, Fuentes and her videographer staked out the ferry landing, surveying everyone boarding the ferry for 10 days. Schaefer and his entourage never appeared. </span></p>
-<p><span>But using her time to keep researching, Fuentes discovered something else: a man named Peter Schmidt had purchased a truck in Buenos Aires, and to do so he had provided an address. This Peter Schmidt lived in a small town called Chivilcoy, in southern Argentina. Though there was no guarantee that this was the same Peter Schmidt they were looking for, this was another enticing lead. The trip was already getting expensive, but Fuentes had a feeling this was worth following. With permission from her supervisors back in Santiago, Fuentes and her cameraman went to Chivilcoy.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/134/030_fuentes_to_chivilcoy.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_484.html" class="page-previous" title="Go to previous page">&#171;&#160;CONTACTO</a>
-
-<a href="case_id_49_id_486.html" class="page-next" title="Go to next page">Chivilcoy&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Leads to Argentina
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Leads to Argentina
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Fuentes soon obtained a second piece of evidence that suggested Schaefer might be in Argentina: the names of three of Schaefer’s inner circle—Peter Schmidt, Renate Freitag, and Friedhelm Zeitner—appeared on a log of ferry departures from Argentina to Uruguay. With this second mention of Argentina, Fuentes was persuaded: it was time to take a look for herself. So in mid-January 2004, she approached Editor
+         </span>
+         Rodríguez
+         <span>
+          to propose a trip to Buenos Aires. Because the flight was inexpensive,
+         </span>
+         Rodríguez
+         <span>
+          said yes. With the log and a photo of Schmidt as her only clues, Fuentes and a cameraman traveled to Buenos Aires.
+         </span>
+        </p>
+        <p>
+         <span>
+          By analyzing the dates in the travel log, they determined that Schmidt and the others were traveling to Uruguay every three months, most likely to renew their tourist visas. Excited to find that their arrival in Argentina coincided with the date of the Schaefer associates’ next probable trip, Fuentes and her videographer staked out the ferry landing, surveying everyone boarding the ferry for 10 days. Schaefer and his entourage never appeared.
+         </span>
+        </p>
+        <p>
+         <span>
+          But using her time to keep researching, Fuentes discovered something else: a man named Peter Schmidt had purchased a truck in Buenos Aires, and to do so he had provided an address. This Peter Schmidt lived in a small town called Chivilcoy, in southern Argentina. Though there was no guarantee that this was the same Peter Schmidt they were looking for, this was another enticing lead. The trip was already getting expensive, but Fuentes had a feeling this was worth following. With permission from her supervisors back in Santiago, Fuentes and her cameraman went to Chivilcoy.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/134/030_fuentes_to_chivilcoy.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/9BqNXyaI4xg?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_484.html" title="Go to previous page">
+          « CONTACTO
+         </a>
+         <a class="page-next" href="case_id_49_id_486.html" title="Go to next page">
+          Chivilcoy »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_486.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_486.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Chivilcoy | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Chivilcoy | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,342 +84,304 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Chivilcoy</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Chivilcoy</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Arriving at the address listed in the registration, Fuentes was surprised to discover that it was not a residence, but a business called Calandrino&rsquo;s Auto Shop.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/136/032_33_34_fuentes_following_schmidt.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Discouraged, Fuentes and her cinematographer returned to Calandrino&rsquo;s auto shop and decided to wait.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/126/005_fuentes_setup_colonia.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Fuentes thought she had pinpointed where Schmidt lived, but what was she to do next? She had hoped to get visual evidence of Schaefer&rsquo;s whereabouts, and then report him to the authorities. But she still had not seen him, much less filmed him. Should she try to get more information from Calandrino? </span></p>
-<p><b><i>What next?</i></b><span> Unsure of how to proceed, Fuentes called the news office in Santiago. Her editors were delighted with her breakthrough. But they also realized that this could well be only the start of a long, arduous investigation. Fuentes decided to return to Santiago to consult with Executive Editor Baz&aacute;n Cardemil and Editor </span>Rodr&iacute;guez<span>.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/137/037_fuentes_dilemma_being_chilean.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>The group had an idea: why not send someone who was not Chilean and who would thus not seem suspicious to the Germans? Baz&aacute;n Cardemil already had someone in mind&mdash;a Spanish/Italian investigative reporter on the CONTACTO staff named Gustavo Villarrubia. Villarrubia had lived all over the world and spoke several languages; better yet, his accent was not Chilean. </span>Rodr&iacute;guez<span> proposed that Villarrubia go to Chivilcoy disguised as someone else. The team was leaning toward this option, but all three had concerns: Should a journalist go undercover?</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_485.html" class="page-previous" title="Go to previous page">&#171;&#160;Leads to Argentina</a>
-
-<a href="case_id_49_id_487.html" class="page-next" title="Go to next page">Is undercover justified?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Chivilcoy
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Chivilcoy
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Arriving at the address listed in the registration, Fuentes was surprised to discover that it was not a residence, but a business called Calandrino’s Auto Shop.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/136/032_33_34_fuentes_following_schmidt.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/SVY037rG5NM?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Discouraged, Fuentes and her cinematographer returned to Calandrino’s auto shop and decided to wait.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/126/005_fuentes_setup_colonia.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/OAb5FzKTH50?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Fuentes thought she had pinpointed where Schmidt lived, but what was she to do next? She had hoped to get visual evidence of Schaefer’s whereabouts, and then report him to the authorities. But she still had not seen him, much less filmed him. Should she try to get more information from Calandrino?
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           What next?
+          </i>
+         </b>
+         <span>
+          Unsure of how to proceed, Fuentes called the news office in Santiago. Her editors were delighted with her breakthrough. But they also realized that this could well be only the start of a long, arduous investigation. Fuentes decided to return to Santiago to consult with Executive Editor Bazán Cardemil and Editor
+         </span>
+         Rodríguez
+         <span>
+          .
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/137/037_fuentes_dilemma_being_chilean.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/SOGIAcF-7s8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          The group had an idea: why not send someone who was not Chilean and who would thus not seem suspicious to the Germans? Bazán Cardemil already had someone in mind—a Spanish/Italian investigative reporter on the CONTACTO staff named Gustavo Villarrubia. Villarrubia had lived all over the world and spoke several languages; better yet, his accent was not Chilean.
+         </span>
+         Rodríguez
+         <span>
+          proposed that Villarrubia go to Chivilcoy disguised as someone else. The team was leaning toward this option, but all three had concerns: Should a journalist go undercover?
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_485.html" title="Go to previous page">
+          « Leads to Argentina
+         </a>
+         <a class="page-next" href="case_id_49_id_487.html" title="Go to next page">
+          Is undercover justified? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_487.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_487.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Is undercover justified? | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Is undercover justified? | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,342 +84,297 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Is undercover justified?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Is undercover justified?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p>Rodr&iacute;guez<span> convened a meeting with Baz&aacute;n Cardemil, Fuentes, and Villarrubia. Villarrubia was eager to get to Argentina. He was an old hand at undercover journalism, and had no hesitations about this project. But going to Chivilcoy to investigate Paul Schaefer under false pretenses raised some serious questions for the editors. Villarrubia would have to deceive people in the community in order to find Schaefer. Was that fair? What was the problem if Villarrubia simply identified himself as a journalist? </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/138/041_fuentes_on_ethical_doubts.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Baz&aacute;n Cardemil added that, while this was not the way she preferred to conduct CONTACTO investigations, it may have been justified by the bigger picture.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/139/042_cardemil_on_disguises.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Moreover, like Fuentes she was worried about the ethical implications of tipping off Schaefer so he could escape again.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/140/045_cardemil_on_considering_undercover.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><b><i>Which cover?</i></b><span> So Baz&aacute;n Cardemil came around. Villarrubia could go to Chivilcoy undercover. She did, however, have one condition: if the investigation was a success, before airing the final story they would return to Chivilcoy and tell their informants the truth. They would explain the reasons for the deception and ask for consent from those who appeared on film.</span></p>
-<p><span>That still left a practical dilemma: how to concoct a credible disguise? Villarrubia came up with a good one. He had Italian roots, and they knew that over 80 percent of the population in the Chivilcoy region was of Italian descent. After debating various options, it was decided that Villarrubia would assume the identity of a sociologist researching the backgrounds of the Italian families in the region. For the investigation, he decided to use his Italian father&rsquo;s last name, Sburlatti. </span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_486.html" class="page-previous" title="Go to previous page">&#171;&#160;Chivilcoy</a>
-
-<a href="case_id_49_id_488.html" class="page-next" title="Go to next page">Digging In&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Is undercover justified?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Is undercover justified?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         Rodríguez
+         <span>
+          convened a meeting with Bazán Cardemil, Fuentes, and Villarrubia. Villarrubia was eager to get to Argentina. He was an old hand at undercover journalism, and had no hesitations about this project. But going to Chivilcoy to investigate Paul Schaefer under false pretenses raised some serious questions for the editors. Villarrubia would have to deceive people in the community in order to find Schaefer. Was that fair? What was the problem if Villarrubia simply identified himself as a journalist?
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/138/041_fuentes_on_ethical_doubts.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/_oeRduW8kug?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Bazán Cardemil added that, while this was not the way she preferred to conduct CONTACTO investigations, it may have been justified by the bigger picture.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/139/042_cardemil_on_disguises.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/2cfQxAV5tFU?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Moreover, like Fuentes she was worried about the ethical implications of tipping off Schaefer so he could escape again.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/140/045_cardemil_on_considering_undercover.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/1fIkHxRM8lE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           Which cover?
+          </i>
+         </b>
+         <span>
+          So Bazán Cardemil came around. Villarrubia could go to Chivilcoy undercover. She did, however, have one condition: if the investigation was a success, before airing the final story they would return to Chivilcoy and tell their informants the truth. They would explain the reasons for the deception and ask for consent from those who appeared on film.
+         </span>
+        </p>
+        <p>
+         <span>
+          That still left a practical dilemma: how to concoct a credible disguise? Villarrubia came up with a good one. He had Italian roots, and they knew that over 80 percent of the population in the Chivilcoy region was of Italian descent. After debating various options, it was decided that Villarrubia would assume the identity of a sociologist researching the backgrounds of the Italian families in the region. For the investigation, he decided to use his Italian father’s last name, Sburlatti.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_486.html" title="Go to previous page">
+          « Chivilcoy
+         </a>
+         <a class="page-next" href="case_id_49_id_488.html" title="Go to next page">
+          Digging In »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_488.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_488.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Digging In | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Digging In | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,339 +84,278 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Digging In</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Digging In</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>In March 2004, Fuentes briefly returned to Chivilcoy with Villarrubia to show him what she had already found there. The two rented a plane and did one more flyover of the ranch, a trip that revealed only how isolated and unapproachable the property was. When Fuentes returned to Santiago to continue background research on the story, Villarrubia stayed behind in Chivilcoy. His first goal was to build a relationship with Juan Carlos Calandrino, the owner of the auto shop where Peter Schmidt&rsquo;s car was registered. Villarrubia hoped that Calandrino would provide valuable information on the Germans. But befriending Calandrino would also help him maintain the fa&ccedil;ade that he was investigating Italian immigration to the area. </span></p>
-<p><span>Villarrubia approached an Italian notary who, judging by the size of the advertisement he had placed in the phonebook, appeared to be a pillar of the community. Basic Internet research revealed that the man&rsquo;s family, the Gardellas, had probably emigrated from Naples, a fact that he enthusiastically confirmed when Villarrubia paid his office a visit. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/141/052_villarrubia_on_italian_community.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>The notary willingly allowed Villarrubia to use his name in approaching others in town, including Calandrino. Eventually, Villarrubia was able to approach Calandrino and befriend him. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/142/055_054_villarrubia_on_calandrino.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Over the next few days, Villarrubia spent most of his time either with Calandrino or researching the genealogies of locals, as if he really were an Italian sociologist. In the meantime, he wondered how he could get close to the neighbors of the German ranch, called La Solita.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_487.html" class="page-previous" title="Go to previous page">&#171;&#160;Is undercover justified?</a>
-
-<a href="case_id_49_id_489.html" class="page-next" title="Go to next page">Hugo Placente&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Digging In
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Digging In
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          In March 2004, Fuentes briefly returned to Chivilcoy with Villarrubia to show him what she had already found there. The two rented a plane and did one more flyover of the ranch, a trip that revealed only how isolated and unapproachable the property was. When Fuentes returned to Santiago to continue background research on the story, Villarrubia stayed behind in Chivilcoy. His first goal was to build a relationship with Juan Carlos Calandrino, the owner of the auto shop where Peter Schmidt’s car was registered. Villarrubia hoped that Calandrino would provide valuable information on the Germans. But befriending Calandrino would also help him maintain the façade that he was investigating Italian immigration to the area.
+         </span>
+        </p>
+        <p>
+         <span>
+          Villarrubia approached an Italian notary who, judging by the size of the advertisement he had placed in the phonebook, appeared to be a pillar of the community. Basic Internet research revealed that the man’s family, the Gardellas, had probably emigrated from Naples, a fact that he enthusiastically confirmed when Villarrubia paid his office a visit.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/141/052_villarrubia_on_italian_community.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/OZurZWBQU_4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          The notary willingly allowed Villarrubia to use his name in approaching others in town, including Calandrino. Eventually, Villarrubia was able to approach Calandrino and befriend him.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/142/055_054_villarrubia_on_calandrino.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/CmIWwHwfkp0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Over the next few days, Villarrubia spent most of his time either with Calandrino or researching the genealogies of locals, as if he really were an Italian sociologist. In the meantime, he wondered how he could get close to the neighbors of the German ranch, called La Solita.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_487.html" title="Go to previous page">
+          « Is undercover justified?
+         </a>
+         <a class="page-next" href="case_id_49_id_489.html" title="Go to next page">
+          Hugo Placente »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_489.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_489.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Hugo Placente | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Hugo Placente | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,345 +84,302 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Hugo Placente</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Hugo Placente</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Soon, Calandrino mentioned that his old friend, Hugo Placente, lived next door to the Germans. Villarrubia immediately saw the opening he had been waiting for.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/143/057_villarrubia_seeing_placente.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Feeling that he now had a reason to visit Placente, Villarrubia drove to his home again the following day.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/144/058_59_villarrubia_returns.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<div>Villarrubia was elated.</div>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/145/060_villarrubia_story_reaction.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Treading carefully, Villarrubia decided to press Placente on what he knew of the Germans.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/146/061_villarrubia_germans_suspicious_actions.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>During this visit, Villarrubia also befriended a young couple who worked on Placente&rsquo;s ranch. They were friendly and welcomed Villarrubia, who saw that their house was situated on the edge of the property and offered clear views of La Solita. </span></p>
-<p><span>In April 2004, pleased with his research, Villarrubia returned to Santiago to report on his findings. </span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_488.html" class="page-previous" title="Go to previous page">&#171;&#160;Digging In</a>
-
-<a href="case_id_49_id_490.html" class="page-next" title="Go to next page">Dangerous People&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Hugo Placente
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Hugo Placente
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Soon, Calandrino mentioned that his old friend, Hugo Placente, lived next door to the Germans. Villarrubia immediately saw the opening he had been waiting for.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/143/057_villarrubia_seeing_placente.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/SDrpHEb5rhY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Feeling that he now had a reason to visit Placente, Villarrubia drove to his home again the following day.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/144/058_59_villarrubia_returns.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/zyh6eRhYqEE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <div>
+         Villarrubia was elated.
+        </div>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/145/060_villarrubia_story_reaction.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/HoO7cZtCeDQ?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Treading carefully, Villarrubia decided to press Placente on what he knew of the Germans.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/146/061_villarrubia_germans_suspicious_actions.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/9o6G1CBg8fI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          During this visit, Villarrubia also befriended a young couple who worked on Placente’s ranch. They were friendly and welcomed Villarrubia, who saw that their house was situated on the edge of the property and offered clear views of La Solita.
+         </span>
+        </p>
+        <p>
+         <span>
+          In April 2004, pleased with his research, Villarrubia returned to Santiago to report on his findings.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_488.html" title="Go to previous page">
+          « Digging In
+         </a>
+         <a class="page-next" href="case_id_49_id_490.html" title="Go to next page">
+          Dangerous People »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_490.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_490.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Dangerous People | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Dangerous People | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,337 +84,272 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Dangerous People</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Dangerous People</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>In Santiago, Villarrubia described everything, including the extensive security measures the Germans had put in place. This made Baz&aacute;n Cardemil nervous. She had overseen reporters&mdash;including Villarrubia&mdash;who worked in dangerous places, and she believed that reporters who agreed to such assignments bore some of the risk. But she knew that, if anything happened, the responsibility was ultimately hers.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/147/064_cardemil_we_dont_need_heroes.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Baz&aacute;n Cardemil made sure that, after this first trip, Villarrubia didn&rsquo;t go to Chivilcoy alone again. For her part, Pilar </span>Rodr&iacute;guez<span> trusted Villarrubia, but also had concerns about his &ldquo;no limits&rdquo; attitude.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/148/066_rodriguez_on_villarrubias_limits.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_489.html" class="page-previous" title="Go to previous page">&#171;&#160;Hugo Placente</a>
-
-<a href="case_id_49_id_491.html" class="page-next" title="Go to next page">The Second Trip&#8212;an Unmasking&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Dangerous People
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Dangerous People
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          In Santiago, Villarrubia described everything, including the extensive security measures the Germans had put in place. This made Bazán Cardemil nervous. She had overseen reporters—including Villarrubia—who worked in dangerous places, and she believed that reporters who agreed to such assignments bore some of the risk. But she knew that, if anything happened, the responsibility was ultimately hers.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/147/064_cardemil_we_dont_need_heroes.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/sLcfmZkznB0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Bazán Cardemil made sure that, after this first trip, Villarrubia didn’t go to Chivilcoy alone again. For her part, Pilar
+         </span>
+         Rodríguez
+         <span>
+          trusted Villarrubia, but also had concerns about his “no limits” attitude.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/148/066_rodriguez_on_villarrubias_limits.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/XCNpRi_nC3Y?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_489.html" title="Go to previous page">
+          « Hugo Placente
+         </a>
+         <a class="page-next" href="case_id_49_id_491.html" title="Go to next page">
+          The Second Trip—an Unmasking »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_491.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_491.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>The Second Trip&#8212;an Unmasking | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   The Second Trip—an Unmasking | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,346 +84,311 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>The Second Trip&#8212;an Unmasking</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">The Second Trip&#8212;an Unmasking</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>In May 2004, Villarrubia returned for a short stay in Chivilcoy, this time accompanied by a videographer. He continued to spend time with Placente and Calandrino, with whom he had become particularly close. To his fellow reporter Fuentes, this was troubling.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/156/068_fuentes_on_villarrubia_calandrino_relationship.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>As it happened, in the course of his confessions Calandrino revealed something Villarrubia found troubling.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/157/069_villarrubia_calandrino_grandson_to_la_solita.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Villarrubia did not know what to do. Calandrino was friendly with the Germans, and Villarrubia was not sure how loyal he felt towards them. If he told Calandrino the truth, Calandrino could easily relay that to the Germans, thereby jeopardizing not only the CONTACTO investigation but any chance of bringing Schaefer to justice for his crimes. On the other hand, Villarrubia felt strongly that the safety of the child was paramount. Villarrubia, unable to reach his editors in Santiago, had to make the call on the spot.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/158/070_villarrubia_tells_calandrino.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>When Villarrubia was finally able to contact Fuentes and </span>Rodr&iacute;guez<span> and tell them what he had done, they were at first furious. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/159/071_072_fuentes_rodriguez_react.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes &amp; Rodr&iacute;guez</span></p>
-<p><span>For his part, Villarrubia felt confident he had done the right thing. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/178/073_villarrubia_lose_investigation.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_490.html" class="page-previous" title="Go to previous page">&#171;&#160;Dangerous People</a>
-
-<a href="case_id_49_id_492.html" class="page-next" title="Go to next page">The Hidden Camera Dilemma&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          The Second Trip—an Unmasking
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       The Second Trip—an Unmasking
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          In May 2004, Villarrubia returned for a short stay in Chivilcoy, this time accompanied by a videographer. He continued to spend time with Placente and Calandrino, with whom he had become particularly close. To his fellow reporter Fuentes, this was troubling.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/156/068_fuentes_on_villarrubia_calandrino_relationship.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/UAYBw8btqKk?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          As it happened, in the course of his confessions Calandrino revealed something Villarrubia found troubling.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/157/069_villarrubia_calandrino_grandson_to_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/d5Xn9LEvln4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Villarrubia did not know what to do. Calandrino was friendly with the Germans, and Villarrubia was not sure how loyal he felt towards them. If he told Calandrino the truth, Calandrino could easily relay that to the Germans, thereby jeopardizing not only the CONTACTO investigation but any chance of bringing Schaefer to justice for his crimes. On the other hand, Villarrubia felt strongly that the safety of the child was paramount. Villarrubia, unable to reach his editors in Santiago, had to make the call on the spot.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/158/070_villarrubia_tells_calandrino.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/4XNytB8zfuY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          When Villarrubia was finally able to contact Fuentes and
+         </span>
+         Rodríguez
+         <span>
+          and tell them what he had done, they were at first furious.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/159/071_072_fuentes_rodriguez_react.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/0I_OZI7FBvQ?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes &amp; Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          For his part, Villarrubia felt confident he had done the right thing.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/178/073_villarrubia_lose_investigation.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/7v5y5-jwmm4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_490.html" title="Go to previous page">
+          « Dangerous People
+         </a>
+         <a class="page-next" href="case_id_49_id_492.html" title="Go to next page">
+          The Hidden Camera Dilemma »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_492.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_492.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>The Hidden Camera Dilemma | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   The Hidden Camera Dilemma | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,338 +84,277 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>The Hidden Camera Dilemma</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">The Hidden Camera Dilemma</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Meanwhile, Villarrubia had another problem. His research would eventually result in a documentary, and for that he needed compelling images. But neither the villagers in Chivilcoy nor the Germans living at La Solita were likely to agree to be filmed. So the CONTACTO editorial team decided that both the videographer and Villarrubia would carry hidden cameras. </span></p>
-<p><span>The use of hidden cameras was a common tactic in CONTACTO investigations, and was widely used in Chilean journalism in general. Chilean law technically prohibited capturing private images and conversations. However, the courts had generally found in the journalist&rsquo;s favor if the resulting report benefited the public. The point, proponents argued, was to capture images that could prove the otherwise unprovable. At CONTACTO, their use was subject to the discretion of the editor in charge.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/160/076_077_cardemil_on_hidden_camera.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Admittedly, there were problems. What happened if a journalist using a hidden camera was discovered by the authorities or, worse, by someone armed and dangerous? How could a reporter know in advance whether his story would be of vital public importance? </span>Rodr&iacute;guez<span> acknowledged that the lines were somewhat fuzzy, and subjective. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/161/079_080_rodriguez_hidden_camera_permanent_dilemma.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_491.html" class="page-previous" title="Go to previous page">&#171;&#160;The Second Trip&#8212;an Unmasking</a>
-
-<a href="case_id_49_id_493.html" class="page-next" title="Go to next page">Undercover in Chivilcoy&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          The Hidden Camera Dilemma
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       The Hidden Camera Dilemma
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Meanwhile, Villarrubia had another problem. His research would eventually result in a documentary, and for that he needed compelling images. But neither the villagers in Chivilcoy nor the Germans living at La Solita were likely to agree to be filmed. So the CONTACTO editorial team decided that both the videographer and Villarrubia would carry hidden cameras.
+         </span>
+        </p>
+        <p>
+         <span>
+          The use of hidden cameras was a common tactic in CONTACTO investigations, and was widely used in Chilean journalism in general. Chilean law technically prohibited capturing private images and conversations. However, the courts had generally found in the journalist’s favor if the resulting report benefited the public. The point, proponents argued, was to capture images that could prove the otherwise unprovable. At CONTACTO, their use was subject to the discretion of the editor in charge.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/160/076_077_cardemil_on_hidden_camera.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/SweIHyMkgVY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Admittedly, there were problems. What happened if a journalist using a hidden camera was discovered by the authorities or, worse, by someone armed and dangerous? How could a reporter know in advance whether his story would be of vital public importance?
+         </span>
+         Rodríguez
+         <span>
+          acknowledged that the lines were somewhat fuzzy, and subjective.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/161/079_080_rodriguez_hidden_camera_permanent_dilemma.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/dizJE_t-bU4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_491.html" title="Go to previous page">
+          « The Second Trip—an Unmasking
+         </a>
+         <a class="page-next" href="case_id_49_id_493.html" title="Go to next page">
+          Undercover in Chivilcoy »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_493.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_493.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Undercover in Chivilcoy | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Undercover in Chivilcoy | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,336 +84,265 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Undercover in Chivilcoy</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Undercover in Chivilcoy</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>In Chivilcoy, Villarrubia and his cameraman continued to investigate who lived at La Solita. To do this, the pair used some innovative methods to track the activities of Peter Schmidt and his accomplice, Friedhelm Zeitner (alias Felipe). With the cameraman stationed in town and Villarrubia near La Solita, they spoke in code over the phone to signal the Germans&rsquo; comings and goings. They took turns following them by car, and soon patterns began to emerge. Anyone leaving the house for Chivilcoy, Villarrubia noticed, always followed a circuitous route, and their trips to town often included a stop at a phone center. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/162/082_83_villarrubia_on_tactics.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>But neither Villarrubia nor his videographer ever confronted the two men. It was unlikely that they would cooperate, and Villarrubia did not want to tip them off and make them flee La Solita&mdash;which was conveniently located near an airstrip. Moreover, Villarrubia knew that the two men were well-trained in martial arts and armed. This was a period of increased violence in the Argentine countryside; homicides and armed robberies were up sharply. Villarrubia did not want to run the risk of becoming just another data point.&nbsp;</span></p>
-<p><span>On the other hand, how long could he secretly trail Schaefer&rsquo;s bodyguards? His editors back in Santiago began to question whether this approach would ever bear fruit. It was already May, and Villarrubia had made several trips to Chivilcoy. He had ascertained many of the bodyguards&rsquo; habits, but had still not located Schaefer.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_492.html" class="page-previous" title="Go to previous page">&#171;&#160;The Hidden Camera Dilemma</a>
-
-<a href="case_id_49_id_494.html" class="page-next" title="Go to next page">Cops and Robbers?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Undercover in Chivilcoy
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Undercover in Chivilcoy
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          In Chivilcoy, Villarrubia and his cameraman continued to investigate who lived at La Solita. To do this, the pair used some innovative methods to track the activities of Peter Schmidt and his accomplice, Friedhelm Zeitner (alias Felipe). With the cameraman stationed in town and Villarrubia near La Solita, they spoke in code over the phone to signal the Germans’ comings and goings. They took turns following them by car, and soon patterns began to emerge. Anyone leaving the house for Chivilcoy, Villarrubia noticed, always followed a circuitous route, and their trips to town often included a stop at a phone center.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/162/082_83_villarrubia_on_tactics.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/bIQ-xccXbSQ?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          But neither Villarrubia nor his videographer ever confronted the two men. It was unlikely that they would cooperate, and Villarrubia did not want to tip them off and make them flee La Solita—which was conveniently located near an airstrip. Moreover, Villarrubia knew that the two men were well-trained in martial arts and armed. This was a period of increased violence in the Argentine countryside; homicides and armed robberies were up sharply. Villarrubia did not want to run the risk of becoming just another data point.
+         </span>
+        </p>
+        <p>
+         <span>
+          On the other hand, how long could he secretly trail Schaefer’s bodyguards? His editors back in Santiago began to question whether this approach would ever bear fruit. It was already May, and Villarrubia had made several trips to Chivilcoy. He had ascertained many of the bodyguards’ habits, but had still not located Schaefer.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_492.html" title="Go to previous page">
+          « The Hidden Camera Dilemma
+         </a>
+         <a class="page-next" href="case_id_49_id_494.html" title="Go to next page">
+          Cops and Robbers? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_494.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_494.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Cops and Robbers? | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Cops and Robbers? | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,337 +84,268 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Cops and Robbers?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Cops and Robbers?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia was a veteran investigative reporter who had worked all over the world on stories about drug smuggling and arms trafficking. The work was often secretive and dangerous. But as the investigation in Chivilcoy continued, Villarrubia&rsquo;s methods increasingly began to resemble those of a detective. In Santiago, Executive Editor Baz&aacute;n Cardemil returned to a question raised by much of CONTACTO&rsquo;s work: what was the line between a journalistic investigation, and a police one? </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/164/084_cardemil_journalist_involvement_dilemma.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>But Baz&aacute;n Cardemil&rsquo;s team was willing to go further in pushing this line. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/165/085_086_rodriguez_fuentes_investigative_methods.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Rodr&iacute;guez &amp; Fuentes</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_493.html" class="page-previous" title="Go to previous page">&#171;&#160;Undercover in Chivilcoy</a>
-
-<a href="case_id_49_id_495.html" class="page-next" title="Go to next page">Doubts in Santiago&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Cops and Robbers?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Cops and Robbers?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia was a veteran investigative reporter who had worked all over the world on stories about drug smuggling and arms trafficking. The work was often secretive and dangerous. But as the investigation in Chivilcoy continued, Villarrubia’s methods increasingly began to resemble those of a detective. In Santiago, Executive Editor Bazán Cardemil returned to a question raised by much of CONTACTO’s work: what was the line between a journalistic investigation, and a police one?
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/164/084_cardemil_journalist_involvement_dilemma.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/SMU99BonurI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          But Bazán Cardemil’s team was willing to go further in pushing this line.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/165/085_086_rodriguez_fuentes_investigative_methods.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/u9UQXVVmaX8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez &amp; Fuentes
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_493.html" title="Go to previous page">
+          « Undercover in Chivilcoy
+         </a>
+         <a class="page-next" href="case_id_49_id_495.html" title="Go to next page">
+          Doubts in Santiago »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_495.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_495.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Doubts in Santiago | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Doubts in Santiago | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,340 +84,290 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Doubts in Santiago</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Doubts in Santiago</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Meanwhile, Executive Editor Baz&aacute;n Cardemil and Editor </span>Rodr&iacute;guez<span> were growing impatient. It was already July, and the segment they had intended to air on Schaefer was still not ready. Villarrubia was six months into an increasingly expensive investigation, yet had no real proof that Schaefer was even at the compound in Chivilcoy. Tension at CONTACTO began to mount. From his position in the field, Villarrubia had strong feelings.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/166/092_089_villarrubia_editors_pressure.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p>Rodr&iacute;guez<span> was one of those pressing Villarrubia for results. She wondered just how much longer it would take to find something&mdash;and whether there was anything to find at all.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/167/090_rodriguez_expensive_gamble.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p>
-<p><span>But there was no Plan B. Histories of <i>Colonia Dignidad</i> had been done before. In order to justify airing a new story about Paul Schaefer, CONTACTO would have to find him. Fuentes and Villarrubia would not relent; they steadfastly defended the investigation and advocated it continue.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/172/092_villarrubia_fuentes_dont_give_up.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_494.html" class="page-previous" title="Go to previous page">&#171;&#160;Cops and Robbers?</a>
-
-<a href="case_id_49_id_496.html" class="page-next" title="Go to next page">La Solita&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Doubts in Santiago
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Doubts in Santiago
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Meanwhile, Executive Editor Bazán Cardemil and Editor
+         </span>
+         Rodríguez
+         <span>
+          were growing impatient. It was already July, and the segment they had intended to air on Schaefer was still not ready. Villarrubia was six months into an increasingly expensive investigation, yet had no real proof that Schaefer was even at the compound in Chivilcoy. Tension at CONTACTO began to mount. From his position in the field, Villarrubia had strong feelings.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/166/092_089_villarrubia_editors_pressure.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/j5T1Cn-neZc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         Rodríguez
+         <span>
+          was one of those pressing Villarrubia for results. She wondered just how much longer it would take to find something—and whether there was anything to find at all.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/167/090_rodriguez_expensive_gamble.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/DeqiRfZ7m_Y?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          But there was no Plan B. Histories of
+          <i>
+           Colonia Dignidad
+          </i>
+          had been done before. In order to justify airing a new story about Paul Schaefer, CONTACTO would have to find him. Fuentes and Villarrubia would not relent; they steadfastly defended the investigation and advocated it continue.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/172/092_villarrubia_fuentes_dont_give_up.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/4H_cZxPAYKY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_494.html" title="Go to previous page">
+          « Cops and Robbers?
+         </a>
+         <a class="page-next" href="case_id_49_id_496.html" title="Go to next page">
+          La Solita »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_496.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_496.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>La Solita | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   La Solita | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,339 +84,278 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>La Solita</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">La Solita</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia decided to step up his examination of La Solita. Except for movement he had observed on its fields, the ranch was still a mystery. It was closed to visitors. Neighbors who wanted to visit had to call the house in advance to arrange an appointment&mdash;and give the Germans time to activate their security mechanisms. The main house was hidden deep on the large property and surrounded by tall trees, which made movement in the house impossible to see. In fact, Villarrubia&rsquo;s only glimpse of the main ranch house had been from the air, when he and Fuentes rented an airplane in March.</span></p>
-<p><span>Frustrated at his lack of progress after months of investigation and acting on a whim, Villarrubia decided on a more radical course of action: enter La Solita. Perhaps, he reasoned, he could spot Paul Schaefer. An opportunity arose when Villarrubia suggested to one of Hugo Placente&rsquo;s laborers that they take his new calf to La Solita to be vaccinated. The Germans had both the knowledge and the equipment to handle such matters, so the farm worker quickly agreed. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/171/094_villarrubia_entering_la_solita.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Finally, the two men were allowed onto the grounds. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/173/095_096_villarrubia_camera_loses_signal.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Terrified, Villarrubia consulted with friends in Buenos Aires to figure out what had happened to his camera. The Germans, it turned out, as soon as Villarrubia rang the doorbell had activated an electro-magnetic field around La Solita to neutralize any recording activity.&nbsp;</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_495.html" class="page-previous" title="Go to previous page">&#171;&#160;Doubts in Santiago</a>
-
-<a href="case_id_49_id_497.html" class="page-next" title="Go to next page">A Breakthrough&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          La Solita
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       La Solita
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia decided to step up his examination of La Solita. Except for movement he had observed on its fields, the ranch was still a mystery. It was closed to visitors. Neighbors who wanted to visit had to call the house in advance to arrange an appointment—and give the Germans time to activate their security mechanisms. The main house was hidden deep on the large property and surrounded by tall trees, which made movement in the house impossible to see. In fact, Villarrubia’s only glimpse of the main ranch house had been from the air, when he and Fuentes rented an airplane in March.
+         </span>
+        </p>
+        <p>
+         <span>
+          Frustrated at his lack of progress after months of investigation and acting on a whim, Villarrubia decided on a more radical course of action: enter La Solita. Perhaps, he reasoned, he could spot Paul Schaefer. An opportunity arose when Villarrubia suggested to one of Hugo Placente’s laborers that they take his new calf to La Solita to be vaccinated. The Germans had both the knowledge and the equipment to handle such matters, so the farm worker quickly agreed.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/171/094_villarrubia_entering_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/A9mjZHFj-PQ?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Finally, the two men were allowed onto the grounds.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/173/095_096_villarrubia_camera_loses_signal.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/WT1KaFaIMOI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Terrified, Villarrubia consulted with friends in Buenos Aires to figure out what had happened to his camera. The Germans, it turned out, as soon as Villarrubia rang the doorbell had activated an electro-magnetic field around La Solita to neutralize any recording activity.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_495.html" title="Go to previous page">
+          « Doubts in Santiago
+         </a>
+         <a class="page-next" href="case_id_49_id_497.html" title="Go to next page">
+          A Breakthrough »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_497.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_497.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>A Breakthrough | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   A Breakthrough | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,339 +84,278 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>A Breakthrough</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">A Breakthrough</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Throughout the fall of 2004, Villarrubia continued to defy his editors&rsquo; skepticism and visit Chivilcoy. In October, he spent time at Hugo Placente&rsquo;s ranch, where he was able to piece together more of the puzzle of Schaefer&rsquo;s entourage. He was certain that all the major figures were currently at La Solita. He discovered, for instance, that a young man who looked more Hispanic than the German bodyguards was actually &ldquo;Martin,&rdquo; the alias of Matthias Gerlach, an adopted Chilean who was Schaefer&rsquo;s favorite. His presence at the ranch was significant. </span></p>
-<p><span>Bodyguard Felipe had always seemed suspicious of Villarrubia, and apparently went to some lengths to avoid him. But on occasion, Felipe came by with gifts of cheese from La Solita in order to talk business with Placente. In early November 2004, one of these visits bore fruit.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/174/098_villarrubia_schaefer_is_alive.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Furthermore, Villarrubia&rsquo;s painstaking observation of movements at La Solita was proving useful. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/175/099_villarrubia_everyone_at_la_solita.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>By mid-November, Villarrubia knew it was time to move.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_496.html" class="page-previous" title="Go to previous page">&#171;&#160;La Solita</a>
-
-<a href="case_id_49_id_498.html" class="page-next" title="Go to next page">Nowhere to Turn?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          A Breakthrough
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       A Breakthrough
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Throughout the fall of 2004, Villarrubia continued to defy his editors’ skepticism and visit Chivilcoy. In October, he spent time at Hugo Placente’s ranch, where he was able to piece together more of the puzzle of Schaefer’s entourage. He was certain that all the major figures were currently at La Solita. He discovered, for instance, that a young man who looked more Hispanic than the German bodyguards was actually “Martin,” the alias of Matthias Gerlach, an adopted Chilean who was Schaefer’s favorite. His presence at the ranch was significant.
+         </span>
+        </p>
+        <p>
+         <span>
+          Bodyguard Felipe had always seemed suspicious of Villarrubia, and apparently went to some lengths to avoid him. But on occasion, Felipe came by with gifts of cheese from La Solita in order to talk business with Placente. In early November 2004, one of these visits bore fruit.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/174/098_villarrubia_schaefer_is_alive.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/85ruzpdk5ZU?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Furthermore, Villarrubia’s painstaking observation of movements at La Solita was proving useful.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/175/099_villarrubia_everyone_at_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/Z1wmy6Cu67g?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          By mid-November, Villarrubia knew it was time to move.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_496.html" title="Go to previous page">
+          « La Solita
+         </a>
+         <a class="page-next" href="case_id_49_id_498.html" title="Go to next page">
+          Nowhere to Turn? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/49/casestudy/www/layout/case_id_49_id_498.html
+++ b/casestudies/49/casestudy/www/layout/case_id_49_id_498.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Nowhere to Turn? | Reporters or cops? CONTACTO and the search for Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Nowhere to Turn? | Reporters or cops? CONTACTO and the search for Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,338 +84,280 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_49.html" title="Home"><span>Nowhere to Turn?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_49.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_481.html">Introduction</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_482.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_483.html">Schaefer and the Chilean Authorities</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_484.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_485.html">Leads to Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_486.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_487.html">Is undercover justified?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_488.html">Digging In</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_489.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_490.html">Dangerous People</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_491.html">The Second Trip&#8212;an Unmasking</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_492.html">The Hidden Camera Dilemma</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_493.html">Undercover in Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_494.html">Cops and Robbers?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_495.html">Doubts in Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_496.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_49_id_497.html">A Breakthrough</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_49_id_498.html">Nowhere to Turn?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/49/CONTACTO&#32;ENGLISH_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_49.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Nowhere to Turn?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia returned to Santiago and described his findings to the rest of the team. Baz&aacute;n Cardemil knew it was time to approach the authorities. The CONTACTO investigation, she felt, could go no further on its own. But the team members were wary of approaching the authorities, for several reasons. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/176/104_102_rodriguez_villarrubia_doubts_about_police.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez &amp; Villarrubia</span></p>
-<p><span>Reporter Fuentes was afraid to trust the Argentine authorities. After all, the Chilean police had likely helped Schaefer escape arrest in 1997. Who was to say the Argentine police were any more reliable? Instead, she and the Schaefer victims&rsquo; lawyer, Fernandez, explored other avenues, such as two human rights organizations&mdash;but to no avail. </span></p>
-<p><span>Another option was to approach Interpol, a politically neutral, international police agency that could track criminals across borders. But what if Schaefer had protection there, too? Schaefer was, after all, skilled at cultivating support where he needed it. Even if the police organization were untainted, what if Interpol investigators accepted the evidence CONTACTO had gathered for the past year, yet did not allow them to film the moment of arrest? Without this moment on tape, any resulting documentary would be significantly weakened. Could CONTACTO risk hobbling itself after all the time and resources it had dedicated to the project?</span></p>
-<p><span>As they debated their options, Villarrubia had returned yet again to Chivilcoy to keep an eye on the situation. When he arrived, he found the situation had become significantly more tense. The Germans at La Solita had become suspicious about his inquiries and began asking their neighbors about Villarrubia. Soon they began telling the neighbors that Villarrubia was a spy for the CIA. Then, Villarrubia had an alarming encounter with Peter Schmidt, the chief bodyguard and most dangerous of La Solita&rsquo;s residents.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/177/106_villarrubia_confrontation_peter_schmidt.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Clearly, time was running out for Villarrubia and his undercover investigation. The CONTACTO team knew that now was the time to take action, before Schaefer slipped away again. Just what that action should be, however, was far from clear. </span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_49_id_497.html" class="page-previous" title="Go to previous page">&#171;&#160;A Breakthrough</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/49/knightcase_logo_contacto.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_49.html" title="Home">
+         <span>
+          Nowhere to Turn?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_49.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_481.html">
+          Introduction
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_482.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_483.html">
+          Schaefer and the Chilean Authorities
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_484.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_485.html">
+          Leads to Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_486.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_487.html">
+          Is undercover justified?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_488.html">
+          Digging In
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_489.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_490.html">
+          Dangerous People
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_491.html">
+          The Second Trip—an Unmasking
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_492.html">
+          The Hidden Camera Dilemma
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_493.html">
+          Undercover in Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_494.html">
+          Cops and Robbers?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_495.html">
+          Doubts in Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_496.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_49_id_497.html">
+          A Breakthrough
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_49_id_498.html">
+          Nowhere to Turn?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/49/CONTACTO ENGLISH_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_49.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Nowhere to Turn?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia returned to Santiago and described his findings to the rest of the team. Bazán Cardemil knew it was time to approach the authorities. The CONTACTO investigation, she felt, could go no further on its own. But the team members were wary of approaching the authorities, for several reasons.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/176/104_102_rodriguez_villarrubia_doubts_about_police.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/-xT12eky4mc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez &amp; Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Reporter Fuentes was afraid to trust the Argentine authorities. After all, the Chilean police had likely helped Schaefer escape arrest in 1997. Who was to say the Argentine police were any more reliable? Instead, she and the Schaefer victims’ lawyer, Fernandez, explored other avenues, such as two human rights organizations—but to no avail.
+         </span>
+        </p>
+        <p>
+         <span>
+          Another option was to approach Interpol, a politically neutral, international police agency that could track criminals across borders. But what if Schaefer had protection there, too? Schaefer was, after all, skilled at cultivating support where he needed it. Even if the police organization were untainted, what if Interpol investigators accepted the evidence CONTACTO had gathered for the past year, yet did not allow them to film the moment of arrest? Without this moment on tape, any resulting documentary would be significantly weakened. Could CONTACTO risk hobbling itself after all the time and resources it had dedicated to the project?
+         </span>
+        </p>
+        <p>
+         <span>
+          As they debated their options, Villarrubia had returned yet again to Chivilcoy to keep an eye on the situation. When he arrived, he found the situation had become significantly more tense. The Germans at La Solita had become suspicious about his inquiries and began asking their neighbors about Villarrubia. Soon they began telling the neighbors that Villarrubia was a spy for the CIA. Then, Villarrubia had an alarming encounter with Peter Schmidt, the chief bodyguard and most dangerous of La Solita’s residents.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/177/106_villarrubia_confrontation_peter_schmidt.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/jB5eiyrA0Tg?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Clearly, time was running out for Villarrubia and his undercover investigation. The CONTACTO team knew that now was the time to take action, before Schaefer slipped away again. Just what that action should be, however, was far from clear.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_49_id_497.html" title="Go to previous page">
+          « A Breakthrough
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_505.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_505.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Paul Schaefer | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Paul Schaefer | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,349 +84,379 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Paul Schaefer</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Paul Schaefer</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Los miembros del equipo de CONTACTO ya estaban familiarizados con las l&iacute;neas generales de la inusual historia personal de Schaefer, pero ten&iacute;an que recordarse a s&iacute; mismos los detalles. Schaefer, seg&uacute;n aprendi&oacute; el equipo de noticias, naci&oacute; en 1921 cerca de la frontera holandesa en Troisderf, Alemania. </span><span>Al inicio de la Segunda Guerra Mundial, Schaefer se convirti&oacute; en un m&eacute;dico y sirvi&oacute; en la guerra durante la ocupaci&oacute;n de Francia.</span></p>
-<p><span>Un cristiano evang&eacute;lico, Schaefer trabaj&oacute; brevemente como director de j&oacute;venes de una iglesia, pero fue despedido por sospechas de que hab&iacute;a abusado de algunos de los ni&ntilde;os a su cuidado. As&iacute;, Schaefer tom&oacute; el camino como ministro. Ten&iacute;a gran carisma y en unos pocos a&ntilde;os hab&iacute;a atra&iacute;do a varios cientos de seguidores y creado una comunidad religiosa para las viudas y los hu&eacute;rfanos de la guerra en Sieburg, cerca de Bonn.</span></p>
-<p><span>Sin embargo, a principios de 1960, dos madres se quejaron a las autoridades alemanas de que Schaefer abusaba sexualmente de sus hijos. Schaefer huy&oacute; antes de que pudiera ser detenido. Su destino final: Chile, a donde lleg&oacute; en 1964 con varios cientos de hombres, mujeres y ni&ntilde;os que cre&iacute;an en Schaefer y la visi&oacute;n que el promov&iacute;a de un ideal de comunidad alemana. </span></p>
-<p><b><i>Colonia Dignidad.</i></b><i> </i><span>En <i>Colonia Dignidad</i>, Schaefer recre&oacute; una versi&oacute;n de fantas&iacute;a de una aldea alemana de su juventud. </span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/179/005_1_fuentes_setup_colonia.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Los residentes conservaban su nacionalidad alemana, llevaban la ropa tradicional alemana y todo el mundo, incluidos los ni&ntilde;os de Chile adoptados por las comunidades vecinas, hablaban alem&aacute;n.</span><a title="" name="_ftnref1" href="case_id_50_id_505.html#_ftn1"><span><span><span><span>[1]</span></span></span></span></a><span> <i>Colonia Dignidad</i>, en 33.000 hect&aacute;reas, se convirti&oacute; en un estado dentro del estado.</span><a title="" name="_ftnref2" href="case_id_50_id_505.html#_ftn2"><span><span><span><span>[2]</span></span></span></span></a><span> Los residentes, que ten&iacute;an que confesar diariamente sus pecados a Schaefer, no se les permit&iacute;a salir fuera de la <i>Colonia</i>, donde trabajaban largas horas sin compensaci&oacute;n. Deb&iacute;an lealtad completa a Schaefer, quien regularmente abusaba sexualmente de los ni&ntilde;os peque&ntilde;os que viv&iacute;an en la colonia. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/180/004_1_fuentes_mechanism_sex_abuse.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<div><br clear="all" />
-<hr width="33%" size="1" align="left" />
-<div id="ftn1">
-<p><span style="font-size: smaller;"><a title="" name="_ftn1" href="case_id_50_id_505.html#_ftnref1">[1]</a> Shirley Christian, </span><span><span><a href="http://www.nytimes.com/1988/03/26/world/santiago-journal-at-a-chilean-utopia-dark-tales-of-dread-doings.html?scp=1&amp;sq=At%20a%20Chilean%20%E2%80%98Utopia,%E2%80%99%20Dark%20Tales%20of%20Dread%20Doing&amp;st=cse" target="_blank" class="extlink"><span style="font-size: smaller;">&ldquo;Santiago Journal: At a Chilean &lsquo;Utopia,&rsquo; Dark Tales of Dread Doing,&rdquo;</span></a></span></span> <i><span style="font-size: smaller;">New York Times</span></i><span style="font-size: smaller;">, March 26, 1988.</span></p>
-</div>
-<div id="ftn2">
-<p><a title="" name="_ftn2" href="case_id_50_id_505.html#_ftnref2"></a><span style="font-size: smaller;"><a title="" name="_ftn2" href="case_id_50_id_505.html#_ftnref2">[2]</a> &ldquo;Rights group seeks protection for secret Chilean enclave,&rdquo; <i>Agence France Presse</i>, September 19, 1997.</span></p>
-</div>
-</div></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_504.html" class="page-previous" title="Go to previous page">&#171;&#160;Introducci&oacute;n</a>
-
-<a href="case_id_50_id_506.html" class="page-next" title="Go to next page">Schaefer y las autoridades chilenas&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Paul Schaefer
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Paul Schaefer
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Los miembros del equipo de CONTACTO ya estaban familiarizados con las líneas generales de la inusual historia personal de Schaefer, pero tenían que recordarse a sí mismos los detalles. Schaefer, según aprendió el equipo de noticias, nació en 1921 cerca de la frontera holandesa en Troisderf, Alemania.
+         </span>
+         <span>
+          Al inicio de la Segunda Guerra Mundial, Schaefer se convirtió en un médico y sirvió en la guerra durante la ocupación de Francia.
+         </span>
+        </p>
+        <p>
+         <span>
+          Un cristiano evangélico, Schaefer trabajó brevemente como director de jóvenes de una iglesia, pero fue despedido por sospechas de que había abusado de algunos de los niños a su cuidado. Así, Schaefer tomó el camino como ministro. Tenía gran carisma y en unos pocos años había atraído a varios cientos de seguidores y creado una comunidad religiosa para las viudas y los huérfanos de la guerra en Sieburg, cerca de Bonn.
+         </span>
+        </p>
+        <p>
+         <span>
+          Sin embargo, a principios de 1960, dos madres se quejaron a las autoridades alemanas de que Schaefer abusaba sexualmente de sus hijos. Schaefer huyó antes de que pudiera ser detenido. Su destino final: Chile, a donde llegó en 1964 con varios cientos de hombres, mujeres y niños que creían en Schaefer y la visión que el promovía de un ideal de comunidad alemana.
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           Colonia Dignidad.
+          </i>
+         </b>
+         <i>
+         </i>
+         <span>
+          En
+          <i>
+           Colonia Dignidad
+          </i>
+          , Schaefer recreó una versión de fantasía de una aldea alemana de su juventud.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/179/005_1_fuentes_setup_colonia.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/5DT2_JgKsQE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Los residentes conservaban su nacionalidad alemana, llevaban la ropa tradicional alemana y todo el mundo, incluidos los niños de Chile adoptados por las comunidades vecinas, hablaban alemán.
+         </span>
+         <a href="case_id_50_id_505.html#_ftn1" name="_ftnref1" title="">
+          <span>
+           <span>
+            <span>
+             <span>
+              [1]
+             </span>
+            </span>
+           </span>
+          </span>
+         </a>
+         <span>
+          <i>
+           Colonia Dignidad
+          </i>
+          , en 33.000 hectáreas, se convirtió en un estado dentro del estado.
+         </span>
+         <a href="case_id_50_id_505.html#_ftn2" name="_ftnref2" title="">
+          <span>
+           <span>
+            <span>
+             <span>
+              [2]
+             </span>
+            </span>
+           </span>
+          </span>
+         </a>
+         <span>
+          Los residentes, que tenían que confesar diariamente sus pecados a Schaefer, no se les permitía salir fuera de la
+          <i>
+           Colonia
+          </i>
+          , donde trabajaban largas horas sin compensación. Debían lealtad completa a Schaefer, quien regularmente abusaba sexualmente de los niños pequeños que vivían en la colonia.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/180/004_1_fuentes_mechanism_sex_abuse.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/3LRYQDmfy6g?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <div>
+         <br clear="all"/>
+         <hr align="left" size="1" width="33%"/>
+         <div id="ftn1">
+          <p>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_505.html#_ftnref1" name="_ftn1" title="">
+             [1]
+            </a>
+            Shirley Christian,
+           </span>
+           <span>
+            <span>
+             <a class="extlink" href="http://www.nytimes.com/1988/03/26/world/santiago-journal-at-a-chilean-utopia-dark-tales-of-dread-doings.html?scp=1&amp;sq=At%20a%20Chilean%20%E2%80%98Utopia,%E2%80%99%20Dark%20Tales%20of%20Dread%20Doing&amp;st=cse" target="_blank">
+              <span style="font-size: smaller;">
+               “Santiago Journal: At a Chilean ‘Utopia,’ Dark Tales of Dread Doing,”
+              </span>
+             </a>
+            </span>
+           </span>
+           <i>
+            <span style="font-size: smaller;">
+             New York Times
+            </span>
+           </i>
+           <span style="font-size: smaller;">
+            , March 26, 1988.
+           </span>
+          </p>
+         </div>
+         <div id="ftn2">
+          <p>
+           <a href="case_id_50_id_505.html#_ftnref2" name="_ftn2" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_505.html#_ftnref2" name="_ftn2" title="">
+             [2]
+            </a>
+            “Rights group seeks protection for secret Chilean enclave,”
+            <i>
+             Agence France Presse
+            </i>
+            , September 19, 1997.
+           </span>
+          </p>
+         </div>
+        </div>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_504.html" title="Go to previous page">
+          « Introducción
+         </a>
+         <a class="page-next" href="case_id_50_id_506.html" title="Go to next page">
+          Schaefer y las autoridades chilenas »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_506.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_506.html
@@ -1,39 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<head>
-  <title>Schaefer y las autoridades chilenas | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Schaefer y las autoridades chilenas | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-<style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -41,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -67,358 +84,468 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Schaefer y las autoridades chilenas</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Schaefer y las autoridades chilenas</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Schaefer y sus allegados</span><span>, muchos de los cuales hab&iacute;an servido en las Waffen-SS y la Gestapo durante la Segunda Guerra Mundial,</span><span> crearon un sistema de seguridad elaborado: </span><span>una red de t&uacute;neles y refugios subterr&aacute;neos, torres de vigilancia, puestos de guardia, perversos perros guardianes y entrenamiento militar para los hombres de la colonia, cada uno de los cuales llevaba un arma. <i>Colonia Dignidad</i>, tambi&eacute;n ten&iacute;a sus propios aeropuertos y aviones, sistema telef&oacute;nico interno, planta el&eacute;ctrica, una f&aacute;brica de ladrillos y un laboratorio de armas qu&iacute;micas</span>.<a href="case_id_50_id_506.html#_ftn1" name="_ftnref1" title=""><span><span>[1]</span></span></a></p>
-<p><span>El p&uacute;blico sab&iacute;a poco acerca de la Colonia, que se hizo muy pr&oacute;spera por medio de la venta de pan, verduras y queso en la comunidad. El inter&eacute;s se despert&oacute; en la d&eacute;cada de 1960, cuando empezaron a llegar los detalles del recinto cerrado (uno de los residentes se escap&oacute; en 1966 en su tercer intento). Pero Schaefer ten&iacute;a protecci&oacute;n m&aacute;s all&aacute; de su sistema de seguridad.  Cultivaba las relaciones con las autoridades, los colmaba de regalos y patrocin&oacute; proyectos de caridad. Los medios de comunicaci&oacute;n rara vez tuvieron acceso a la Colonia Dignidad. Cuando fueron, los periodistas fueron agasajados con una imagen muy coreografiada de benefactor. </span></p>
-<p><span>El m&aacute;s poderoso protector de Schaefer fue su buen amigo, Augusto Pinochet, quien tom&oacute; el poder en Chile el 11 de septiembre de 1973 y estableci&oacute; una dictadura militar autoritaria. El r&eacute;gimen de Pinochet detuvo a miles de chilenos bajo la sospecha de pertenecer a la oposici&oacute;n y muchos fueron torturados y asesinados. <i>Colonia Dignidad</i> fue un lugar donde Pinochet podr&iacute;a contar con apoyo.</span><a href="case_id_50_id_506.html#_ftn2" name="_ftnref2" title=""><span><span>[2]</span></span></a></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/181/009_1_fuentes_hospital_torture.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>En la d&eacute;cada de 1990, Schaefer libremente hab&iacute;a abusado de los menores en la Colonia por m&aacute;s de 20 a&ntilde;os. Bajo el disfraz de un programa de beneficencia para la juventud local, que incluso extendi&oacute; su alcance a la comunidad circundante. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/182/010_1_fuentes_schaefer_abuse_chilean_children.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><b><i>El vuelo de Schaefer.</i></b><span> Cuando Pinochet en 1990 fue sustituido por un gobierno democr&aacute;tico, la red de protecci&oacute;n de Schaefer sufri&oacute; un gran golpe. El sucesor de Pinochet, Patricio Aylwin, en 1992, revoc&oacute; el estatus de la <i>Colonia</i> como una organizaci&oacute;n no lucrativa despu&eacute;s que Schaefer fue acusado de evasi&oacute;n de impuestos. Luego, en 1997, dos colonos j&oacute;venes escaparon. Alegaron que Schaefer hab&iacute;a abusado de ellos, as&iacute; como de ni&ntilde;os de tan s&oacute;lo ocho a&ntilde;os.</span><a href="case_id_50_id_506.html#_ftn3" name="_ftnref3" title=""><span><span><span><span>[3]</span></span></span></span></a><span> En mayo de 1997, el juez Hern&aacute;n Gonz&aacute;lez, dict&oacute; una orden de detenci&oacute;n a Schaefer, as&iacute; como a10 allegados, en relaci&oacute;n a unas 40 investigaciones.</span><a href="case_id_50_id_506.html#_ftn4" name="_ftnref4" title=""><span><span><span><span>[4]</span></span></span></span></a><span> La polic&iacute;a de Chile y la Interpol se dirigieron a la<i> Colonia</i> para arrestarlo, pero Schaefer hab&iacute;a desaparecido.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/183/012_1_rodriguez_schaefer_escape.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p>
-<p><span>Schaefer hab&iacute;a desaparecido, pero su dominio sobre la imaginaci&oacute;n chilena s&oacute;lo creci&oacute; con los a&ntilde;os. &iquest;Lo que los chilenos se preguntaban, que hab&iacute;a realmente sucedido en el interior de <i>Colonia Dignidad</i>? &iquest;C&oacute;mo hab&iacute;a Schaefer mantenido a cientos de personas esclavizadas? &iquest;Es cierto que los fugitivos nazis como Joseph Mengele se hab&iacute;an escondido, someti&eacute;ndose a cirug&iacute;a pl&aacute;stica en <i>Colonia Dignidad</i>? &iquest;C&oacute;mo tal voraz pedofilia hab&iacute;a quedado impune desde hac&iacute;a d&eacute;cadas? &iquest;Qui&eacute;nes le hab&iacute;an ayudado a escapar? &iquest;D&oacute;nde estaba ahora? </span></p>
-<div><br clear="all" />
-<hr width="33%" size="1" align="left" />
-<div id="ftn1">
-<p><span style="font-size: smaller;"><a href="case_id_50_id_506.html#_ftnref1" name="_ftn1" title="">[1]</a>      Charles A. Krause, &ldquo;Colonia Dignidad: Nobody Comes Goes. Mystery Veils Colony in Chile,&rdquo; <i>Washington</i><i> Post</i>, February 11, 1980.</span></p>
-</div>
-<div id="ftn2">
-<p><a href="case_id_50_id_506.html#_ftnref2" name="_ftn2" title=""></a><span style="font-size: smaller;"><a href="case_id_50_id_506.html#_ftnref2" name="_ftn2" title="">[2]</a>      &ldquo;57<sup>th</sup> lawsuit filed against Pinochet in Chile,&rdquo; <i>Agence France Presse</i>, January 18, 2000; Larry Rohter, </span><a class="extlink" target="_blank" href="http://www.nytimes.com/2002/05/19/ international/americas/19CHIL.html?pagewanted=all&amp;position=bottom"><span style="font-size: smaller;">&ldquo;Chilean Mystery: Clues to Vanished American,&rdquo;</span></a><span style="font-size: smaller;"> <i>New York Times, </i>May 19, 2002</span><span style="font-size: smaller;">. En 1977, Amnist&iacute;a Internacional public&oacute; un reporte alegando que Colonia Dignidad era una base de operaciones de DINA, una polic&iacute;a chilena secreta. (Schaefer fue tambi&eacute;n amigo cercano del General Miguel Contreras, quien dirig&iacute;a DINA). Schaefer demand&oacute; a Amnist&iacute;a Internacional por  difamaci&oacute;n y bloquear la entrada a la colonia a una delegaci&oacute;n de investigaci&oacute;n de Alemania Occidental. Gustavo Gonzalez, &ldquo;Chile-Politics: Net tightens on shady settlement,&rdquo; <i>IPS-Inter Press Service</i>, April 11, 1997.</span></p>
-</div>
-<div id="ftn3">
-<div><a href="case_id_50_id_506.html#_ftnref3" name="_ftn3" title=""></a><span style="font-size: smaller;"><a href="case_id_50_id_506.html#_ftnref3" name="_ftn3" title="">[3]</a>     &ldquo;Two youths in Frankfurt after escaping Colonia Dignidad,&rdquo; <i>Agence France Presse</i>, August 2, 1997.</span></div>
-</div>
-<div id="ftn4">
-<p><a href="case_id_50_id_506.html#_ftnref4" name="_ftn4" title=""></a><span style="font-size: smaller;"><a href="case_id_50_id_506.html#_ftnref4" name="_ftn4" title="">[4]</a>      &ldquo;Chilean judge orders arrest of leaders of former Nazi enclave,&rdquo; <i>Agence France Presse</i>, May 10, 1997.</span></p>
-</div>
-</div></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_505.html" class="page-previous" title="Go to previous page">&#171;&#160;Paul Schaefer</a>
-
-<a href="case_id_50_id_507.html" class="page-next" title="Go to next page">CONTACTO&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Schaefer y las autoridades chilenas
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Schaefer y las autoridades chilenas
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Schaefer y sus allegados
+         </span>
+         <span>
+          , muchos de los cuales habían servido en las Waffen-SS y la Gestapo durante la Segunda Guerra Mundial,
+         </span>
+         <span>
+          crearon un sistema de seguridad elaborado:
+         </span>
+         <span>
+          una red de túneles y refugios subterráneos, torres de vigilancia, puestos de guardia, perversos perros guardianes y entrenamiento militar para los hombres de la colonia, cada uno de los cuales llevaba un arma.
+          <i>
+           Colonia Dignidad
+          </i>
+          , también tenía sus propios aeropuertos y aviones, sistema telefónico interno, planta eléctrica, una fábrica de ladrillos y un laboratorio de armas químicas
+         </span>
+         .
+         <a href="case_id_50_id_506.html#_ftn1" name="_ftnref1" title="">
+          <span>
+           <span>
+            [1]
+           </span>
+          </span>
+         </a>
+        </p>
+        <p>
+         <span>
+          El público sabía poco acerca de la Colonia, que se hizo muy próspera por medio de la venta de pan, verduras y queso en la comunidad. El interés se despertó en la década de 1960, cuando empezaron a llegar los detalles del recinto cerrado (uno de los residentes se escapó en 1966 en su tercer intento). Pero Schaefer tenía protección más allá de su sistema de seguridad.  Cultivaba las relaciones con las autoridades, los colmaba de regalos y patrocinó proyectos de caridad. Los medios de comunicación rara vez tuvieron acceso a la Colonia Dignidad. Cuando fueron, los periodistas fueron agasajados con una imagen muy coreografiada de benefactor.
+         </span>
+        </p>
+        <p>
+         <span>
+          El más poderoso protector de Schaefer fue su buen amigo, Augusto Pinochet, quien tomó el poder en Chile el 11 de septiembre de 1973 y estableció una dictadura militar autoritaria. El régimen de Pinochet detuvo a miles de chilenos bajo la sospecha de pertenecer a la oposición y muchos fueron torturados y asesinados.
+          <i>
+           Colonia Dignidad
+          </i>
+          fue un lugar donde Pinochet podría contar con apoyo.
+         </span>
+         <a href="case_id_50_id_506.html#_ftn2" name="_ftnref2" title="">
+          <span>
+           <span>
+            [2]
+           </span>
+          </span>
+         </a>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/181/009_1_fuentes_hospital_torture.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/DefbOzXplmI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          En la década de 1990, Schaefer libremente había abusado de los menores en la Colonia por más de 20 años. Bajo el disfraz de un programa de beneficencia para la juventud local, que incluso extendió su alcance a la comunidad circundante.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/182/010_1_fuentes_schaefer_abuse_chilean_children.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/l1icwoZCzsM?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           El vuelo de Schaefer.
+          </i>
+         </b>
+         <span>
+          Cuando Pinochet en 1990 fue sustituido por un gobierno democrático, la red de protección de Schaefer sufrió un gran golpe. El sucesor de Pinochet, Patricio Aylwin, en 1992, revocó el estatus de la
+          <i>
+           Colonia
+          </i>
+          como una organización no lucrativa después que Schaefer fue acusado de evasión de impuestos. Luego, en 1997, dos colonos jóvenes escaparon. Alegaron que Schaefer había abusado de ellos, así como de niños de tan sólo ocho años.
+         </span>
+         <a href="case_id_50_id_506.html#_ftn3" name="_ftnref3" title="">
+          <span>
+           <span>
+            <span>
+             <span>
+              [3]
+             </span>
+            </span>
+           </span>
+          </span>
+         </a>
+         <span>
+          En mayo de 1997, el juez Hernán González, dictó una orden de detención a Schaefer, así como a10 allegados, en relación a unas 40 investigaciones.
+         </span>
+         <a href="case_id_50_id_506.html#_ftn4" name="_ftnref4" title="">
+          <span>
+           <span>
+            <span>
+             <span>
+              [4]
+             </span>
+            </span>
+           </span>
+          </span>
+         </a>
+         <span>
+          La policía de Chile y la Interpol se dirigieron a la
+          <i>
+           Colonia
+          </i>
+          para arrestarlo, pero Schaefer había desaparecido.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/183/012_1_rodriguez_schaefer_escape.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/-9vC5BWJ6fk?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          Schaefer había desaparecido, pero su dominio sobre la imaginación chilena sólo creció con los años. ¿Lo que los chilenos se preguntaban, que había realmente sucedido en el interior de
+          <i>
+           Colonia Dignidad
+          </i>
+          ? ¿Cómo había Schaefer mantenido a cientos de personas esclavizadas? ¿Es cierto que los fugitivos nazis como Joseph Mengele se habían escondido, sometiéndose a cirugía plástica en
+          <i>
+           Colonia Dignidad
+          </i>
+          ? ¿Cómo tal voraz pedofilia había quedado impune desde hacía décadas? ¿Quiénes le habían ayudado a escapar? ¿Dónde estaba ahora?
+         </span>
+        </p>
+        <div>
+         <br clear="all"/>
+         <hr align="left" size="1" width="33%"/>
+         <div id="ftn1">
+          <p>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_506.html#_ftnref1" name="_ftn1" title="">
+             [1]
+            </a>
+            Charles A. Krause, “Colonia Dignidad: Nobody Comes Goes. Mystery Veils Colony in Chile,”
+            <i>
+             Washington
+            </i>
+            <i>
+             Post
+            </i>
+            , February 11, 1980.
+           </span>
+          </p>
+         </div>
+         <div id="ftn2">
+          <p>
+           <a href="case_id_50_id_506.html#_ftnref2" name="_ftn2" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_506.html#_ftnref2" name="_ftn2" title="">
+             [2]
+            </a>
+            “57
+            <sup>
+             th
+            </sup>
+            lawsuit filed against Pinochet in Chile,”
+            <i>
+             Agence France Presse
+            </i>
+            , January 18, 2000; Larry Rohter,
+           </span>
+           <a class="extlink" href="http://www.nytimes.com/2002/05/19/ international/americas/19CHIL.html?pagewanted=all&amp;position=bottom" target="_blank">
+            <span style="font-size: smaller;">
+             “Chilean Mystery: Clues to Vanished American,”
+            </span>
+           </a>
+           <span style="font-size: smaller;">
+            <i>
+             New York Times,
+            </i>
+            May 19, 2002
+           </span>
+           <span style="font-size: smaller;">
+            . En 1977, Amnistía Internacional publicó un reporte alegando que Colonia Dignidad era una base de operaciones de DINA, una policía chilena secreta. (Schaefer fue también amigo cercano del General Miguel Contreras, quien dirigía DINA). Schaefer demandó a Amnistía Internacional por  difamación y bloquear la entrada a la colonia a una delegación de investigación de Alemania Occidental. Gustavo Gonzalez, “Chile-Politics: Net tightens on shady settlement,”
+            <i>
+             IPS-Inter Press Service
+            </i>
+            , April 11, 1997.
+           </span>
+          </p>
+         </div>
+         <div id="ftn3">
+          <div>
+           <a href="case_id_50_id_506.html#_ftnref3" name="_ftn3" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_506.html#_ftnref3" name="_ftn3" title="">
+             [3]
+            </a>
+            “Two youths in Frankfurt after escaping Colonia Dignidad,”
+            <i>
+             Agence France Presse
+            </i>
+            , August 2, 1997.
+           </span>
+          </div>
+         </div>
+         <div id="ftn4">
+          <p>
+           <a href="case_id_50_id_506.html#_ftnref4" name="_ftn4" title="">
+           </a>
+           <span style="font-size: smaller;">
+            <a href="case_id_50_id_506.html#_ftnref4" name="_ftn4" title="">
+             [4]
+            </a>
+            “Chilean judge orders arrest of leaders of former Nazi enclave,”
+            <i>
+             Agence France Presse
+            </i>
+            , May 10, 1997.
+           </span>
+          </p>
+         </div>
+        </div>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_505.html" title="Go to previous page">
+          « Paul Schaefer
+         </a>
+         <a class="page-next" href="case_id_50_id_507.html" title="Go to next page">
+          CONTACTO »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_507.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_507.html
@@ -1,42 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<head>
-  <title>CONTACTO | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   CONTACTO | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -44,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -70,340 +84,312 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>CONTACTO</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">CONTACTO</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En diciembre de 2003, seis a&ntilde;os despu&eacute;s que &eacute;l desapareci&oacute;, a una periodista de investigaci&oacute;n del programa de televisi&oacute;n documental CONTACTO,&nbsp;se le ofreci&oacute; una revelaci&oacute;n tentadora sobre&nbsp;el caso de Schaefer.&nbsp;El programa de CONTACTO fue uno de los primeros frutos de la democracia en Chile. Fundada en 1991, CONTACTO&nbsp;era un programa de horario estelar dedicado a investigar reportajes para la televisi&oacute;n, tanto de Chile como del extranjero.<span> </span>Fue transmitido en el <a class="extlink" target="_blank" href="http://contacto.canal13.cl/contacto2/html/">Canal 13</a> y afiliado con la Universidad Cat&oacute;lica. </span></p>
-<p><span>Su peque&ntilde;o equipo de 12 productores y periodistas hab&iacute;an investigado complejas historias de inter&eacute;s sociol&oacute;gico y humano, incluyendo segmentos sobre abuso de menores, tr&aacute;fico de drogas, post-Guerra Fr&iacute;a de Berl&iacute;n, los misioneros en &Aacute;frica, la enfermedad de Parkinson y sobre los pobres que carec&iacute;an de acceso al sistema judicial. Una historia acerca de&nbsp;los ped&oacute;filos extranjeros que huyeron a Chile y vivieron all&iacute; bajo la impunidad, ha provocado casi un cambio en la legislaci&oacute;n. Con todo esto, CONTACTO ha ganado una reputaci&oacute;n seria de periodismo de profundidad, as&iacute; como numerosos premios por su labor.</span></p>
-<p><b><i>Un aviso</i><span>. </span></b><span>En diciembre de 2003, Carola Fuentes, periodista de investigaci&oacute;n en CONTACTO, recibi&oacute; una llamada telef&oacute;nica. Hern&aacute;n Fern&aacute;ndez era el abogado de las v&iacute;ctimas de Schaefer, y alguien bien conocido para CONTACTO. Con los a&ntilde;os, hab&iacute;a proporcionado una gran cantidad de informaci&oacute;n acerca de la <i>Colonia</i>, as&iacute; como los contactos con los miembros supervivientes. Ahora ten&iacute;a un reporte de una fuente an&oacute;nima sobre el paradero de Schaefer, y quer&iacute;a pasar el aviso a CONTACTO. </span></p>
-<embed height="245" width="420" flashvars="file=../../files/videos/184/019_1_fuentes_journalist_joke_call.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Carola Fuentes estaba interesada, pero sab&iacute;a que necesitar&iacute;a m&aacute;s informaci&oacute;n. Sin embargo, ella tom&oacute; la iniciativa de su director ejecutivo. Patricia Baz&aacute;n Cardemil estaba intrigada, pero esc&eacute;ptica. El indicio era tan tenue que estaba cautelosa de enviar a un periodista en lo que f&aacute;cilmente podr&iacute;a ser una b&uacute;squeda absurda. Por otro lado, sab&iacute;a que Fern&aacute;ndez, al menos, era una fuente confiable. </span></p>
-<p><span>Incluso, si la b&uacute;squeda resultara in&uacute;til, Baz&aacute;n Cardemil consider&oacute; que el riesgo&nbsp;podr&iacute;a merecer la pena. Schaefer se hab&iacute;a convertido en una figura m&iacute;tica y abusiva en la sociedad chilena y si Fuentes pudiera encontrarlo, el p&uacute;blico estar&iacute;a fascinado. Baz&aacute;n Cardemil dio a Fuentes luz verde para continuar la historia. Su editora ser&iacute;a Pilar Rodr&iacute;guez. </span></p>
-<p><b><i>Primeros pasos</i><span>.</span></b><span> A trav&eacute;s de Fern&aacute;ndez, Carola Fuentes entrevist&oacute; primero a dos ex colonos. Se dio cuenta de que, aunque no sab&iacute;an la ubicaci&oacute;n exacta de Schaefer, ten&iacute;an bastante informaci&oacute;n &uacute;til. Sab&iacute;an por ejemplo que, Schaefer era incapaz de vivir solo. Viejo y enfermo, donde quiera que estuviera probablemente estar&iacute;a rodeado por un grupo de protecci&oacute;n de cuidadores. La pareja proporcion&oacute; los nombres de varios de los allegados de mayor confianza de Schaefer, los cuales hab&iacute;an desaparecido durante el mismo tiempo que Schaefer. Entre ellos hab&iacute;a una enfermera de ancianos, un cocinero, la hija adoptiva de Schaefer y un especialista en seguridad llamado Peter Schmidt. </span></p>
-<p><span>Advirtieron que Schmidt, la mano derecha y guardaespaldas de Schaefer, era un hombre peligroso. Formado en el karate y pr&aacute;cticas de tiro al blanco, Schmidt hab&iacute;a crecido al lado de Schaefer y su lealtad era incondicional. Fuentes cuenta que esta era su primera ventaja tangible, primero: encontrar a Peter Schmidt, o el resto del c&iacute;rculo &iacute;ntimo de Schaefer y de esta forma podr&iacute;a as&iacute;,&nbsp;encontrar a Paul Schaefer.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_506.html" class="page-previous" title="Go to previous page">&#171;&#160;Schaefer y las autoridades chilenas</a>
-
-<a href="case_id_50_id_508.html" class="page-next" title="Go to next page">Indicios hacia Argentina&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          CONTACTO
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       CONTACTO
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En diciembre de 2003, seis años después que él desapareció, a una periodista de investigación del programa de televisión documental CONTACTO, se le ofreció una revelación tentadora sobre el caso de Schaefer. El programa de CONTACTO fue uno de los primeros frutos de la democracia en Chile. Fundada en 1991, CONTACTO era un programa de horario estelar dedicado a investigar reportajes para la televisión, tanto de Chile como del extranjero.
+          <span>
+          </span>
+          Fue transmitido en el
+          <a class="extlink" href="http://contacto.canal13.cl/contacto2/html/" target="_blank">
+           Canal 13
+          </a>
+          y afiliado con la Universidad Católica.
+         </span>
+        </p>
+        <p>
+         <span>
+          Su pequeño equipo de 12 productores y periodistas habían investigado complejas historias de interés sociológico y humano, incluyendo segmentos sobre abuso de menores, tráfico de drogas, post-Guerra Fría de Berlín, los misioneros en África, la enfermedad de Parkinson y sobre los pobres que carecían de acceso al sistema judicial. Una historia acerca de los pedófilos extranjeros que huyeron a Chile y vivieron allí bajo la impunidad, ha provocado casi un cambio en la legislación. Con todo esto, CONTACTO ha ganado una reputación seria de periodismo de profundidad, así como numerosos premios por su labor.
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           Un aviso
+          </i>
+          <span>
+           .
+          </span>
+         </b>
+         <span>
+          En diciembre de 2003, Carola Fuentes, periodista de investigación en CONTACTO, recibió una llamada telefónica. Hernán Fernández era el abogado de las víctimas de Schaefer, y alguien bien conocido para CONTACTO. Con los años, había proporcionado una gran cantidad de información acerca de la
+          <i>
+           Colonia
+          </i>
+          , así como los contactos con los miembros supervivientes. Ahora tenía un reporte de una fuente anónima sobre el paradero de Schaefer, y quería pasar el aviso a CONTACTO.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/184/019_1_fuentes_journalist_joke_call.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/5KIOpYXxMV4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Carola Fuentes estaba interesada, pero sabía que necesitaría más información. Sin embargo, ella tomó la iniciativa de su director ejecutivo. Patricia Bazán Cardemil estaba intrigada, pero escéptica. El indicio era tan tenue que estaba cautelosa de enviar a un periodista en lo que fácilmente podría ser una búsqueda absurda. Por otro lado, sabía que Fernández, al menos, era una fuente confiable.
+         </span>
+        </p>
+        <p>
+         <span>
+          Incluso, si la búsqueda resultara inútil, Bazán Cardemil consideró que el riesgo podría merecer la pena. Schaefer se había convertido en una figura mítica y abusiva en la sociedad chilena y si Fuentes pudiera encontrarlo, el público estaría fascinado. Bazán Cardemil dio a Fuentes luz verde para continuar la historia. Su editora sería Pilar Rodríguez.
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           Primeros pasos
+          </i>
+          <span>
+           .
+          </span>
+         </b>
+         <span>
+          A través de Fernández, Carola Fuentes entrevistó primero a dos ex colonos. Se dio cuenta de que, aunque no sabían la ubicación exacta de Schaefer, tenían bastante información útil. Sabían por ejemplo que, Schaefer era incapaz de vivir solo. Viejo y enfermo, donde quiera que estuviera probablemente estaría rodeado por un grupo de protección de cuidadores. La pareja proporcionó los nombres de varios de los allegados de mayor confianza de Schaefer, los cuales habían desaparecido durante el mismo tiempo que Schaefer. Entre ellos había una enfermera de ancianos, un cocinero, la hija adoptiva de Schaefer y un especialista en seguridad llamado Peter Schmidt.
+         </span>
+        </p>
+        <p>
+         <span>
+          Advirtieron que Schmidt, la mano derecha y guardaespaldas de Schaefer, era un hombre peligroso. Formado en el karate y prácticas de tiro al blanco, Schmidt había crecido al lado de Schaefer y su lealtad era incondicional. Fuentes cuenta que esta era su primera ventaja tangible, primero: encontrar a Peter Schmidt, o el resto del círculo íntimo de Schaefer y de esta forma podría así, encontrar a Paul Schaefer.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_506.html" title="Go to previous page">
+          « Schaefer y las autoridades chilenas
+         </a>
+         <a class="page-next" href="case_id_50_id_508.html" title="Go to next page">
+          Indicios hacia Argentina »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_508.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_508.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Indicios hacia Argentina | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Indicios hacia Argentina | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,336 +84,265 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Indicios hacia Argentina</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Indicios hacia Argentina</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Fuentes pronto obtuvo una segunda muestra de evidencia que suger&iacute;a que Schaefer podr&iacute;a estar en la Argentina: los nombres de tres personas del c&iacute;rculo &iacute;ntimo de Schaefer: Peter Schmidt, Renate Freitag y Friedhelm Zeitner aparecieron en el registro de salidas del trasbordador de la Argentina a Uruguay. Con esta segunda menci&oacute;n de la Argentina, Fuentes se convenci&oacute;: que ya era hora de de empezar a buscar por s&iacute; misma. As&iacute; que a mediados de enero de 2004, se acerc&oacute; a Editor Rodr&iacute;guez para proponerle un viaje a Buenos Aires. Debido a que el vuelo era econ&oacute;mico, Rodr&iacute;guez acept&oacute;. Con el registro y una foto de Schmidt como su &uacute;nica pista, Fuentes y un camar&oacute;grafo viajaron a Buenos Aires.&nbsp;</span></p>
-<p><span>Mediante el an&aacute;lisis de las fechas en el registro de viajes, determinaron que Schmidt y los otros fueron de viaje a Uruguay cada tres meses, muy probablemente para renovar sus visas de turista. Emocionados al ver que su llegada a la Argentina coincid&iacute;a con la fecha del viaje de los&nbsp;socios de Schaefer, Fuentes y su camar&oacute;grafo estuvieron vigilando el muelle del ferry, encuestando a todos los que abordaban el transbordador durante 10 d&iacute;as. Aunque Schaefer y su s&eacute;quito nunca aparecieron. </span></p>
-<p><span>Pero utilizando su tiempo para seguir investigando, Fuentes descubri&oacute; algo m&aacute;s: un hombre llamado Peter Schmidt hab&iacute;a comprado un cami&oacute;n en Buenos Aires y para ello hab&iacute;a proporcionado una direcci&oacute;n. Este Peter Schmidt viv&iacute;a en un peque&ntilde;o pueblo llamado Chivilcoy, en el sur de Argentina. Aunque no hab&iacute;a evidencia de que este era el mismo Peter Schmidt que estaban buscando, esta era otra pista atractiva. El viaje ya estaba siendo costoso,&nbsp;pero Fuentes ten&iacute;a la sensaci&oacute;n de que val&iacute;a la pena para darle seguimiento. Con la autorizaci&oacute;n de sus supervisores en Santiago, Fuentes y su camar&oacute;grafo fueron a Chivilcoy.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/185/030_1_fuentes_to_chivilcoy.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_507.html" class="page-previous" title="Go to previous page">&#171;&#160;CONTACTO</a>
-
-<a href="case_id_50_id_509.html" class="page-next" title="Go to next page">Chivilcoy&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Indicios hacia Argentina
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Indicios hacia Argentina
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Fuentes pronto obtuvo una segunda muestra de evidencia que sugería que Schaefer podría estar en la Argentina: los nombres de tres personas del círculo íntimo de Schaefer: Peter Schmidt, Renate Freitag y Friedhelm Zeitner aparecieron en el registro de salidas del trasbordador de la Argentina a Uruguay. Con esta segunda mención de la Argentina, Fuentes se convenció: que ya era hora de de empezar a buscar por sí misma. Así que a mediados de enero de 2004, se acercó a Editor Rodríguez para proponerle un viaje a Buenos Aires. Debido a que el vuelo era económico, Rodríguez aceptó. Con el registro y una foto de Schmidt como su única pista, Fuentes y un camarógrafo viajaron a Buenos Aires.
+         </span>
+        </p>
+        <p>
+         <span>
+          Mediante el análisis de las fechas en el registro de viajes, determinaron que Schmidt y los otros fueron de viaje a Uruguay cada tres meses, muy probablemente para renovar sus visas de turista. Emocionados al ver que su llegada a la Argentina coincidía con la fecha del viaje de los socios de Schaefer, Fuentes y su camarógrafo estuvieron vigilando el muelle del ferry, encuestando a todos los que abordaban el transbordador durante 10 días. Aunque Schaefer y su séquito nunca aparecieron.
+         </span>
+        </p>
+        <p>
+         <span>
+          Pero utilizando su tiempo para seguir investigando, Fuentes descubrió algo más: un hombre llamado Peter Schmidt había comprado un camión en Buenos Aires y para ello había proporcionado una dirección. Este Peter Schmidt vivía en un pequeño pueblo llamado Chivilcoy, en el sur de Argentina. Aunque no había evidencia de que este era el mismo Peter Schmidt que estaban buscando, esta era otra pista atractiva. El viaje ya estaba siendo costoso, pero Fuentes tenía la sensación de que valía la pena para darle seguimiento. Con la autorización de sus supervisores en Santiago, Fuentes y su camarógrafo fueron a Chivilcoy.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/185/030_1_fuentes_to_chivilcoy.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/WIg_SWe1Fe4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_507.html" title="Go to previous page">
+          « CONTACTO
+         </a>
+         <a class="page-next" href="case_id_50_id_509.html" title="Go to next page">
+          Chivilcoy »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_509.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_509.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Chivilcoy | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Chivilcoy | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,342 +84,298 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Chivilcoy</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Chivilcoy</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Al llegar a la direcci&oacute;n que aparece en el registro, Fuentes se sorprendi&oacute; al descubrir que no era una residencia, sino un negocio de reparaci&oacute;n llamado Calandrino Auto Shop.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/186/031_1_fuentes_arrives_auto_shop.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Desanimados, Fuentes y el camar&oacute;grafo regresaron al taller mec&aacute;nico Calandrino y decidieron esperar.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/187/032_33_34_1_fuentes_following_schmidt.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Fuentes pens&oacute; que hab&iacute;a ubicado el lugar donde viv&iacute;a Schmidt, pero &iquest;qu&eacute; iba a hacer posteriormente? Ten&iacute;a la esperanza de obtener una prueba visual del paradero de Schaefer, y luego denunciarlo a las autoridades. Aunque ella todav&iacute;a no lo hab&iacute;a visto y mucho menos lo hab&iacute;a filmado. &iquest;Deber&iacute;a tratar de obtener m&aacute;s informaci&oacute;n de Calandrino?</span></p>
-<p><b><i>&iquest;Qu&eacute; sigue?</i><span> </span></b><span>Sin estar segura de c&oacute;mo proceder, Fuentes llam&oacute; a la oficina de prensa en Santiago.&nbsp;Sus editores estaban encantados por su haza&ntilde;a. Pero tambi&eacute;n se dio cuenta de que esto podr&iacute;a ser s&oacute;lo el comienzo de una larga y ardua investigaci&oacute;n. Fuentes decidi&oacute; regresar a Santiago a consultar con el editor ejecutivo Baz&aacute;n Cardemil y Editor Rodr&iacute;guez.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/188/037_1_fuentes_dilemma_being_chilean.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>El grupo tuvo una idea: &iquest;por qu&eacute; no enviar a alguien que no fuera chileno y por lo tanto, no pareciera sospechoso a los alemanes? Baz&aacute;n Cardemil ya ten&iacute;a a alguien en mente, un espa&ntilde;ol/italiano periodista de investigaci&oacute;n en el personal de CONTACTO llamado Gustavo Villarrubia. Villarrubia hab&iacute;a vivido en todo el mundo y hablaba&nbsp;varios idiomas, mejor a&uacute;n, su acento no era chileno. Rodr&iacute;guez propuso que Villarrubia fuera a Chivilcoy encubierto con&nbsp;otra identidad. El equipo se inclin&oacute; por esta opci&oacute;n, pero los tres ten&iacute;an problemas: &iquest;Debe un periodista ir de inc&oacute;gnito?</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_508.html" class="page-previous" title="Go to previous page">&#171;&#160;Indicios hacia Argentina</a>
-
-<a href="case_id_50_id_510.html" class="page-next" title="Go to next page">&iquest;Se justifica ir encubierto?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Chivilcoy
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Chivilcoy
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Al llegar a la dirección que aparece en el registro, Fuentes se sorprendió al descubrir que no era una residencia, sino un negocio de reparación llamado Calandrino Auto Shop.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/186/031_1_fuentes_arrives_auto_shop.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/-a2wnHsAWB4?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Desanimados, Fuentes y el camarógrafo regresaron al taller mecánico Calandrino y decidieron esperar.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/187/032_33_34_1_fuentes_following_schmidt.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/5vkLdNgZRtI?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Fuentes pensó que había ubicado el lugar donde vivía Schmidt, pero ¿qué iba a hacer posteriormente? Tenía la esperanza de obtener una prueba visual del paradero de Schaefer, y luego denunciarlo a las autoridades. Aunque ella todavía no lo había visto y mucho menos lo había filmado. ¿Debería tratar de obtener más información de Calandrino?
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           ¿Qué sigue?
+          </i>
+          <span>
+          </span>
+         </b>
+         <span>
+          Sin estar segura de cómo proceder, Fuentes llamó a la oficina de prensa en Santiago. Sus editores estaban encantados por su hazaña. Pero también se dio cuenta de que esto podría ser sólo el comienzo de una larga y ardua investigación. Fuentes decidió regresar a Santiago a consultar con el editor ejecutivo Bazán Cardemil y Editor Rodríguez.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/188/037_1_fuentes_dilemma_being_chilean.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/_834SlBa6TY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          El grupo tuvo una idea: ¿por qué no enviar a alguien que no fuera chileno y por lo tanto, no pareciera sospechoso a los alemanes? Bazán Cardemil ya tenía a alguien en mente, un español/italiano periodista de investigación en el personal de CONTACTO llamado Gustavo Villarrubia. Villarrubia había vivido en todo el mundo y hablaba varios idiomas, mejor aún, su acento no era chileno. Rodríguez propuso que Villarrubia fuera a Chivilcoy encubierto con otra identidad. El equipo se inclinó por esta opción, pero los tres tenían problemas: ¿Debe un periodista ir de incógnito?
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_508.html" title="Go to previous page">
+          « Indicios hacia Argentina
+         </a>
+         <a class="page-next" href="case_id_50_id_510.html" title="Go to next page">
+          ¿Se justifica ir encubierto? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_510.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_510.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>&iquest;Se justifica ir encubierto? | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   ¿Se justifica ir encubierto? | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,342 +84,296 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>&iquest;Se justifica ir encubierto?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">&iquest;Se justifica ir encubierto?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Rodr&iacute;guez convoc&oacute; a una reuni&oacute;n con Baz&aacute;n Cardemil, Fuentes y Villarrubia. Villarrubia estaba ansioso por llegar a la Argentina. Era un viejo zorro en el periodismo encubierto y no ten&iacute;a dudas acerca de este proyecto. Pero ir a Chivilcoy para investigar a Paul Schaefer bajo falsas pretensiones, hicieron surgir algunas cuestiones importantes para los editores. Villarrubia tendr&iacute;an que enga&ntilde;ar a la gente en la comunidad a fin de encontrar a Schaefer. &iquest;Seria eso justo? &iquest;Cu&aacute;l era el problema si Villarrubia simplemente se identificaba como un periodista? </span></p>
-<embed height="245" width="420" flashvars="file=../../files/videos/189/041_1_fuentes_on_ethical_doubts.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Baz&aacute;n Cardemil agreg&oacute; que, si bien &eacute;sta no era la mejor forma para llevar a cabo investigaciones para CONTACTO, el objetivo final bien podr&iacute;a ser justificado. </span></p>
-<embed height="245" width="420" flashvars="file=../../files/videos/190/042_1_cardemil_on_disguises.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Por otra parte, Fuentes estaba preocupada por las implicaciones &eacute;ticas de haber advertido a Schaefer, por lo que podr&iacute;a volver a escapar.</span></p>
-<embed height="245" width="420" flashvars="file=../../files/videos/191/045_1_cardemil_on_considering_undercover.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><b><i>&iquest;Cu&aacute;l cobertura?</i></b><span> De esta forma Baz&aacute;n Cardemil le daba vueltas al asunto. Villarrubia pod&iacute;a ir a Chivilcoy encubierto. Sin embargo, ella tiene una condici&oacute;n: si la investigaci&oacute;n resultara un &eacute;xito, antes de publicar la historia final, habr&iacute;a que volver a Chivilcoy y hablar con sus informantes de la verdad. Ellos explicar&iacute;an sobre las razones del enga&ntilde;o y pedir&iacute;an el consentimiento de las personas que aparecer&iacute;an en la pel&iacute;cula. </span></p>
-<p><span>Esto sigue dejando un dilema pr&aacute;ctico: &iquest;c&oacute;mo preparar una apariencia cre&iacute;ble? A Villarrubia se le ocurri&oacute; una buena idea. El ten&iacute;a ra&iacute;ces italianas y sab&iacute;a que m&aacute;s del 80 por ciento de la poblaci&oacute;n en la regi&oacute;n de Chivilcoy era de origen italiano. Despu&eacute;s de evaluar diferentes opciones, se decidi&oacute; que Villarrubia asumir&iacute;a la identidad de un soci&oacute;logo que realizar&iacute;a una investigaci&oacute;n sobre los antecedentes de las familias italianas en la regi&oacute;n. Para la investigaci&oacute;n, decidi&oacute; utilizar el apellido italiano de su padre, Sburlatti.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_509.html" class="page-previous" title="Go to previous page">&#171;&#160;Chivilcoy</a>
-
-<a href="case_id_50_id_511.html" class="page-next" title="Go to next page">Profundizando en la Investigaci&oacute;n&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          ¿Se justifica ir encubierto?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       ¿Se justifica ir encubierto?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Rodríguez convocó a una reunión con Bazán Cardemil, Fuentes y Villarrubia. Villarrubia estaba ansioso por llegar a la Argentina. Era un viejo zorro en el periodismo encubierto y no tenía dudas acerca de este proyecto. Pero ir a Chivilcoy para investigar a Paul Schaefer bajo falsas pretensiones, hicieron surgir algunas cuestiones importantes para los editores. Villarrubia tendrían que engañar a la gente en la comunidad a fin de encontrar a Schaefer. ¿Seria eso justo? ¿Cuál era el problema si Villarrubia simplemente se identificaba como un periodista?
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/189/041_1_fuentes_on_ethical_doubts.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/ni83pdudd0k?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Bazán Cardemil agregó que, si bien ésta no era la mejor forma para llevar a cabo investigaciones para CONTACTO, el objetivo final bien podría ser justificado.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/190/042_1_cardemil_on_disguises.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/bEj2Hn5vRzc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Por otra parte, Fuentes estaba preocupada por las implicaciones éticas de haber advertido a Schaefer, por lo que podría volver a escapar.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/191/045_1_cardemil_on_considering_undercover.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/ULcjpET2vig?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <b>
+          <i>
+           ¿Cuál cobertura?
+          </i>
+         </b>
+         <span>
+          De esta forma Bazán Cardemil le daba vueltas al asunto. Villarrubia podía ir a Chivilcoy encubierto. Sin embargo, ella tiene una condición: si la investigación resultara un éxito, antes de publicar la historia final, habría que volver a Chivilcoy y hablar con sus informantes de la verdad. Ellos explicarían sobre las razones del engaño y pedirían el consentimiento de las personas que aparecerían en la película.
+         </span>
+        </p>
+        <p>
+         <span>
+          Esto sigue dejando un dilema práctico: ¿cómo preparar una apariencia creíble? A Villarrubia se le ocurrió una buena idea. El tenía raíces italianas y sabía que más del 80 por ciento de la población en la región de Chivilcoy era de origen italiano. Después de evaluar diferentes opciones, se decidió que Villarrubia asumiría la identidad de un sociólogo que realizaría una investigación sobre los antecedentes de las familias italianas en la región. Para la investigación, decidió utilizar el apellido italiano de su padre, Sburlatti.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_509.html" title="Go to previous page">
+          « Chivilcoy
+         </a>
+         <a class="page-next" href="case_id_50_id_511.html" title="Go to next page">
+          Profundizando en la Investigación »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_511.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_511.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Profundizando en la Investigaci&oacute;n | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Profundizando en la Investigación | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,339 +84,278 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Profundizando en la Investigaci&oacute;n</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Profundizando en la Investigaci&oacute;n</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En marzo de 2004, Fuentes volvi&oacute; brevemente a Chivilcoy con Villarrubia para mostrarle lo que ella ya hab&iacute;a encontrado all&iacute;. Los dos alquilaron un avi&oacute;n y realizaron un vuelo sobre el rancho, un viaje que revelar&iacute;a lo aislado e inaccesible que era la propiedad. Cuando Fuentes regres&oacute; a Santiago para continuar la investigaci&oacute;n sobre los antecedentes de la historia, Villarrubia permaneci&oacute; en Chivilcoy. Su primer objetivo fue desarrollar una relaci&oacute;n con Juan Carlos Calandrino, el propietario del taller mec&aacute;nico donde se registr&oacute; el coche de Peter Schmidt. Villarrubia esperaba que Calandrino proporcionara informaci&oacute;n valiosa sobre los alemanes. Pero haciendo amistad con Calandrino tambi&eacute;n le ayudar&iacute;a a mantener la fachada que estaba utilizando para investigar la inmigraci&oacute;n italiana en la zona. </span></p>
-<p><span>Villarrubia se acerc&oacute; a un notario italiano que, a juzgar por el tama&ntilde;o de la publicidad que hab&iacute;a colocado en el directorio telef&oacute;nico, parec&iacute;a ser un pilar importante de la comunidad. La investigaci&oacute;n b&aacute;sica en Internet revel&oacute; que la familia de este hombre, los Gardella, probablemente hab&iacute;a emigrado de N&aacute;poles, un hecho que confirm&oacute; entusiasmado cuando Villarrubia realiz&oacute; una visita a la oficina de &eacute;ste. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/192/052_1_villarrubia_on_italian_community.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>El notario voluntariamente permiti&oacute; Villarrubia utilizar su nombre para tener acercamiento con&nbsp;otros en la ciudad, incluyendo a Calandrino. Finalmente, Villarrubia fue capaz de acercarse a Calandrino y hacer amistad con &eacute;l.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/193/055_054_1_villarrubia_on_calandrino.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Durante los pr&oacute;ximos d&iacute;as, Villarrubia pas&oacute; la mayor parte de su tiempo, ya sea con Calandrino o investigando las genealog&iacute;as de los locales, como si realmente fuera un soci&oacute;logo italiano. Mientras tanto, se pregunt&oacute; c&oacute;mo pod&iacute;a acercarse a los vecinos de la hacienda alemana, llamada La Solita.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_510.html" class="page-previous" title="Go to previous page">&#171;&#160;&iquest;Se justifica ir encubierto?</a>
-
-<a href="case_id_50_id_512.html" class="page-next" title="Go to next page">Hugo Placente&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Profundizando en la Investigación
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Profundizando en la Investigación
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En marzo de 2004, Fuentes volvió brevemente a Chivilcoy con Villarrubia para mostrarle lo que ella ya había encontrado allí. Los dos alquilaron un avión y realizaron un vuelo sobre el rancho, un viaje que revelaría lo aislado e inaccesible que era la propiedad. Cuando Fuentes regresó a Santiago para continuar la investigación sobre los antecedentes de la historia, Villarrubia permaneció en Chivilcoy. Su primer objetivo fue desarrollar una relación con Juan Carlos Calandrino, el propietario del taller mecánico donde se registró el coche de Peter Schmidt. Villarrubia esperaba que Calandrino proporcionara información valiosa sobre los alemanes. Pero haciendo amistad con Calandrino también le ayudaría a mantener la fachada que estaba utilizando para investigar la inmigración italiana en la zona.
+         </span>
+        </p>
+        <p>
+         <span>
+          Villarrubia se acercó a un notario italiano que, a juzgar por el tamaño de la publicidad que había colocado en el directorio telefónico, parecía ser un pilar importante de la comunidad. La investigación básica en Internet reveló que la familia de este hombre, los Gardella, probablemente había emigrado de Nápoles, un hecho que confirmó entusiasmado cuando Villarrubia realizó una visita a la oficina de éste.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/192/052_1_villarrubia_on_italian_community.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/qlP6NsbSrTY?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          El notario voluntariamente permitió Villarrubia utilizar su nombre para tener acercamiento con otros en la ciudad, incluyendo a Calandrino. Finalmente, Villarrubia fue capaz de acercarse a Calandrino y hacer amistad con él.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/193/055_054_1_villarrubia_on_calandrino.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/awZqTjNdUa8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Durante los próximos días, Villarrubia pasó la mayor parte de su tiempo, ya sea con Calandrino o investigando las genealogías de los locales, como si realmente fuera un sociólogo italiano. Mientras tanto, se preguntó cómo podía acercarse a los vecinos de la hacienda alemana, llamada La Solita.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_510.html" title="Go to previous page">
+          « ¿Se justifica ir encubierto?
+         </a>
+         <a class="page-next" href="case_id_50_id_512.html" title="Go to next page">
+          Hugo Placente »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_512.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_512.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Hugo Placente | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Hugo Placente | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,345 +84,304 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Hugo Placente</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Hugo Placente</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Pronto, Calandrino mencion&oacute;, que un viejo amigo, Hugo Placente, viv&iacute;a al lado de los alemanes. Villarrubia vio de inmediato la oportunidad que hab&iacute;a estado esperando.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/194/057_1_villarrubia_seeing_placente.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Sintiendo que ahora ten&iacute;a una raz&oacute;n para visitar a Placente, Villarrubia manej&oacute; hacia su casa al d&iacute;a siguiente.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/195/058_59_1_villarrubia_returns.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Villarrubia estaba euf&oacute;rico.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/196/060_1_villarrubia_story_reaction.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Actuando cuidadosamente, Villarrubia decidi&oacute; presionar a Placente acerca de lo que sab&iacute;a sobre los alemanes.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/197/061_1_villarrubia_germans_suspicious_actions.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Durante esta visita, Villarrubia tambi&eacute;n se hizo amigo de una pareja joven que trabajaba en el rancho de Placente. Eran amigables y dieron la bienvenida Villarrubia. Este pudo observar que la casa de la pareja estaba situada al final de la propiedad y ofrec&iacute;a buena&nbsp;vista&nbsp;de &ldquo;La Solita.&rdquo; </span></p>
-<p><span>En abril de 2004, satisfecho con su investigaci&oacute;n, Villarrubia regres&oacute; a Santiago para informar sobre sus hallazgos.</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_511.html" class="page-previous" title="Go to previous page">&#171;&#160;Profundizando en la Investigaci&oacute;n</a>
-
-<a href="case_id_50_id_513.html" class="page-next" title="Go to next page">Gente peligrosa&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Hugo Placente
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Hugo Placente
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Pronto, Calandrino mencionó, que un viejo amigo, Hugo Placente, vivía al lado de los alemanes. Villarrubia vio de inmediato la oportunidad que había estado esperando.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/194/057_1_villarrubia_seeing_placente.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/zZAsBpYY-mE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Sintiendo que ahora tenía una razón para visitar a Placente, Villarrubia manejó hacia su casa al día siguiente.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/195/058_59_1_villarrubia_returns.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/l2AApWBvPlg?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Villarrubia estaba eufórico.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/196/060_1_villarrubia_story_reaction.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/RO4ffXi_tV8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Actuando cuidadosamente, Villarrubia decidió presionar a Placente acerca de lo que sabía sobre los alemanes.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/197/061_1_villarrubia_germans_suspicious_actions.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/paVkISNEnWU?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Durante esta visita, Villarrubia también se hizo amigo de una pareja joven que trabajaba en el rancho de Placente. Eran amigables y dieron la bienvenida Villarrubia. Este pudo observar que la casa de la pareja estaba situada al final de la propiedad y ofrecía buena vista de “La Solita.”
+         </span>
+        </p>
+        <p>
+         <span>
+          En abril de 2004, satisfecho con su investigación, Villarrubia regresó a Santiago para informar sobre sus hallazgos.
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_511.html" title="Go to previous page">
+          « Profundizando en la Investigación
+         </a>
+         <a class="page-next" href="case_id_50_id_513.html" title="Go to next page">
+          Gente peligrosa »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_513.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_513.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Gente peligrosa | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Gente peligrosa | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,338 +84,268 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Gente peligrosa</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Gente peligrosa</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En Santiago, Villarrubia hace una descripci&oacute;n de todo, incluyendo las amplias medidas de seguridad que los alemanes hab&iacute;an puesto en marcha. Esto puso nervioso a Baz&aacute;n Cardemil. Ella hab&iacute;a supervisado a los periodistas incluyendo a Villarrubia, quienes trabajaban en lugares peligrosos y consideraba que los periodistas que hab&iacute;an accedido a ese tipo de asignaciones eluden algunos riesgos. Pero ella sab&iacute;a que si llegaba pasar algo, la responsabilidad en &uacute;ltima instancia ser&iacute;a de ella.</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/198/064_1_cardemil_we_dont_need_heroes.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Baz&aacute;n Cardemil se asegur&oacute; que, despu&eacute;s de este primer viaje, Villarrubia no ir&iacute;a solo de nuevo a Chivilcoy. Por su parte, Pilar Rodr&iacute;guez confiaba en Villarrubia, pero tambi&eacute;n le preocupaba su actitud de &ldquo;sin l&iacute;mites.&quot;</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/199/066_1_rodriguez_on_villarrubias_limits.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">
-Rodr&iacute;guez</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_512.html" class="page-previous" title="Go to previous page">&#171;&#160;Hugo Placente</a>
-
-<a href="case_id_50_id_514.html" class="page-next" title="Go to next page">El Segundo Viaje&#8212;a Desenmascarar&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Gente peligrosa
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Gente peligrosa
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En Santiago, Villarrubia hace una descripción de todo, incluyendo las amplias medidas de seguridad que los alemanes habían puesto en marcha. Esto puso nervioso a Bazán Cardemil. Ella había supervisado a los periodistas incluyendo a Villarrubia, quienes trabajaban en lugares peligrosos y consideraba que los periodistas que habían accedido a ese tipo de asignaciones eluden algunos riesgos. Pero ella sabía que si llegaba pasar algo, la responsabilidad en última instancia sería de ella.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/198/064_1_cardemil_we_dont_need_heroes.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/EdwpzlWk5UQ?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Bazán Cardemil se aseguró que, después de este primer viaje, Villarrubia no iría solo de nuevo a Chivilcoy. Por su parte, Pilar Rodríguez confiaba en Villarrubia, pero también le preocupaba su actitud de “sin límites."
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/199/066_1_rodriguez_on_villarrubias_limits.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/3P3WUSRfBJ8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_512.html" title="Go to previous page">
+          « Hugo Placente
+         </a>
+         <a class="page-next" href="case_id_50_id_514.html" title="Go to next page">
+          El Segundo Viaje—a Desenmascarar »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_514.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_514.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>El Segundo Viaje&#8212;a Desenmascarar | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   El Segundo Viaje—a Desenmascarar | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,346 +84,307 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>El Segundo Viaje&#8212;a Desenmascarar</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">El Segundo Viaje&#8212;a Desenmascarar</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En mayo de 2004, Villarrubia regres&oacute; para una corta estancia en Chivilcoy, esta vez acompa&ntilde;ado de un camar&oacute;grafo. Continu&oacute; pasando tiempo con Placente y Calandrino, con quienes hab&iacute;a establecido un contacto muy cercano. Para Fuentes, su compa&ntilde;ero reportero, esto era problem&aacute;tico.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/200/068_1_fuentes_on_villarrubia_calandrino_relationship.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes</span></p>
-<p><span>Mientras esto suced&iacute;a, en el curso de sus confesiones Calandrino revel&oacute; algo que Villarrubia encontr&oacute; problem&aacute;tico.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/201/069_1_villarrubia_calandrino_grandson_to_la_solita.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Villarrubia no sab&iacute;a qu&eacute; hacer. Calandrino era amigo de los alemanes y Villarrubia no estaba seguro de que tan leal pod&iacute;a ser hacia ellos. Si le dec&iacute;a a Calandrino la verdad, Calandrino f&aacute;cilmente podr&iacute;a transmitir esto a los alemanes, poniendo as&iacute; en peligro no s&oacute;lo la investigaci&oacute;n de CONTACTO, sino tambi&eacute;n cualquier posibilidad de llevar a Schaefer ante la justicia por sus cr&iacute;menes. Por otra parte, Villarrubia cre&iacute;a firmemente que la seguridad del ni&ntilde;o era primordial. Villarrubia, ante la incapacidad de contactar a sus editores en Santiago, tuvo que tomar la decisi&oacute;n en el acto.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/202/070_1_villarrubia_tells_calandrino.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Cuando Villarrubia pudo finalmente ponerse en contacto con Fuentes y Rodr&iacute;guez y decirles lo que hab&iacute;a hecho, al principio se pusieron furiosos.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/203/071_072_1_fuentes_rodriguez_react.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Fuentes &amp; Rodr&iacute;guez</span></p>
-<p><span>Por su parte, Villarrubia confiaba en que &eacute;l hab&iacute;a hecho lo correcto.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/204/073_1_villarrubia_lose_investigation.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_513.html" class="page-previous" title="Go to previous page">&#171;&#160;Gente peligrosa</a>
-
-<a href="case_id_50_id_515.html" class="page-next" title="Go to next page">El dilema de la c&aacute;mara oculta&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          El Segundo Viaje—a Desenmascarar
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       El Segundo Viaje—a Desenmascarar
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En mayo de 2004, Villarrubia regresó para una corta estancia en Chivilcoy, esta vez acompañado de un camarógrafo. Continuó pasando tiempo con Placente y Calandrino, con quienes había establecido un contacto muy cercano. Para Fuentes, su compañero reportero, esto era problemático.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/200/068_1_fuentes_on_villarrubia_calandrino_relationship.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/PgrtucDpIxM?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes
+         </span>
+        </p>
+        <p>
+         <span>
+          Mientras esto sucedía, en el curso de sus confesiones Calandrino reveló algo que Villarrubia encontró problemático.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/201/069_1_villarrubia_calandrino_grandson_to_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/CyWquXk0Lz0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Villarrubia no sabía qué hacer. Calandrino era amigo de los alemanes y Villarrubia no estaba seguro de que tan leal podía ser hacia ellos. Si le decía a Calandrino la verdad, Calandrino fácilmente podría transmitir esto a los alemanes, poniendo así en peligro no sólo la investigación de CONTACTO, sino también cualquier posibilidad de llevar a Schaefer ante la justicia por sus crímenes. Por otra parte, Villarrubia creía firmemente que la seguridad del niño era primordial. Villarrubia, ante la incapacidad de contactar a sus editores en Santiago, tuvo que tomar la decisión en el acto.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/202/070_1_villarrubia_tells_calandrino.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/l52_gSO0yYw?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Cuando Villarrubia pudo finalmente ponerse en contacto con Fuentes y Rodríguez y decirles lo que había hecho, al principio se pusieron furiosos.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/203/071_072_1_fuentes_rodriguez_react.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/cGrjFDzyHqM?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Fuentes &amp; Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          Por su parte, Villarrubia confiaba en que él había hecho lo correcto.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/204/073_1_villarrubia_lose_investigation.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/yvc3WEiDBRk?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_513.html" title="Go to previous page">
+          « Gente peligrosa
+         </a>
+         <a class="page-next" href="case_id_50_id_515.html" title="Go to next page">
+          El dilema de la cámara oculta »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_515.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_515.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>El dilema de la c&aacute;mara oculta | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   El dilema de la cámara oculta | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,338 +84,273 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>El dilema de la c&aacute;mara oculta</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">El dilema de la c&aacute;mara oculta</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Mientras tanto, Villarrubia ten&iacute;a otro problema. Eventualmente, su investigaci&oacute;n se convertir&iacute;a en un documental y para ello necesitar&iacute;a im&aacute;genes convincentes. Pero ni los aldeanos en Chivilcoy, ni los alemanes viviendo en &ldquo;La Solita&rdquo; era probable que accedieran a ser filmados. Por lo que el equipo editorial de CONTACTO decidi&oacute; que tanto el camar&oacute;grafo y Villarrubia llevar&iacute;an ocultas. </span></p>
-<p><span>El uso de c&aacute;maras ocultas fue una t&aacute;ctica com&uacute;n en las investigaciones de CONTACTO y fue ampliamente utilizado en el periodismo chileno en general. T&eacute;cnicamente la legislaci&oacute;n chilena proh&iacute;be la captura de im&aacute;genes y conversaciones privadas. Sin embargo, los tribunales est&aacute;n generalmente a favor del periodista, si el informe resulta en beneficio del p&uacute;blico. El punto, argumentan los defensores, fue la captura de im&aacute;genes que podr&iacute;a ser de alguna otra forma, indemostrable. En CONTACTO, su uso est&aacute; sujeto a la discrecionalidad del editor responsable. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/205/076_077_1_cardemil_on_hidden_camera.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Bazán Cardemil</span></p>
-<p><span>Sin duda, existieron problemas. &iquest;Qu&eacute; pasar&iacute;a si un periodista con una c&aacute;mara oculta fuera descubierto por las autoridades o, peor a&uacute;n, por alguien armado y peligroso? &iquest;C&oacute;mo podr&iacute;a un periodista saber de antemano si su historia ser&iacute;a de vital importancia para el p&uacute;blico? Rodr&iacute;guez reconoci&oacute; que las l&iacute;neas eran un tanto confusas y subjetivas.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/206/079_080_1_rodriguez_hidden_camera_permanent_dilemma.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_514.html" class="page-previous" title="Go to previous page">&#171;&#160;El Segundo Viaje&#8212;a Desenmascarar</a>
-
-<a href="case_id_50_id_516.html" class="page-next" title="Go to next page">Encubierto en Chivilcoy&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          El dilema de la cámara oculta
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       El dilema de la cámara oculta
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Mientras tanto, Villarrubia tenía otro problema. Eventualmente, su investigación se convertiría en un documental y para ello necesitaría imágenes convincentes. Pero ni los aldeanos en Chivilcoy, ni los alemanes viviendo en “La Solita” era probable que accedieran a ser filmados. Por lo que el equipo editorial de CONTACTO decidió que tanto el camarógrafo y Villarrubia llevarían ocultas.
+         </span>
+        </p>
+        <p>
+         <span>
+          El uso de cámaras ocultas fue una táctica común en las investigaciones de CONTACTO y fue ampliamente utilizado en el periodismo chileno en general. Técnicamente la legislación chilena prohíbe la captura de imágenes y conversaciones privadas. Sin embargo, los tribunales están generalmente a favor del periodista, si el informe resulta en beneficio del público. El punto, argumentan los defensores, fue la captura de imágenes que podría ser de alguna otra forma, indemostrable. En CONTACTO, su uso está sujeto a la discrecionalidad del editor responsable.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/205/076_077_1_cardemil_on_hidden_camera.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/3wv63FSuXk0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Sin duda, existieron problemas. ¿Qué pasaría si un periodista con una cámara oculta fuera descubierto por las autoridades o, peor aún, por alguien armado y peligroso? ¿Cómo podría un periodista saber de antemano si su historia sería de vital importancia para el público? Rodríguez reconoció que las líneas eran un tanto confusas y subjetivas.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/206/079_080_1_rodriguez_hidden_camera_permanent_dilemma.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/3BtX8zAPOM0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_514.html" title="Go to previous page">
+          « El Segundo Viaje—a Desenmascarar
+         </a>
+         <a class="page-next" href="case_id_50_id_516.html" title="Go to next page">
+          Encubierto en Chivilcoy »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_516.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_516.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Encubierto en Chivilcoy | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Encubierto en Chivilcoy | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,336 +84,266 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Encubierto en Chivilcoy</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Encubierto en Chivilcoy</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En Chivilcoy, Villarrubia y su camar&oacute;grafo siguieron investigando quien viv&iacute;a en La Solita.&nbsp;Para ello, la pareja utiliz&oacute; algunos m&eacute;todos innovadores para realizar un seguimiento de las actividades de Peter Schmidt y su c&oacute;mplice, Friedhelm Zeitner (alias Felipe). Con el camar&oacute;grafo a cargo en la ciudad y Villarrubia cerca de La Solita, se comunicaban en c&oacute;digo por tel&eacute;fono para rastrear entradas y salidas de los alemanes. Se turnaban para seguirlos en coche y pronto comenzaron a surgir patrones en su forma de actuar. Cualquier persona que sal&iacute;a de la casa de Chivilcoy, Villarrubia notaba que segu&iacute;a siempre un camino en c&iacute;rculo y sus viajes a la ciudad inclu&iacute;an frecuentemente una parada en un centro telef&oacute;nico.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/207/082_083_1_villarrubia_on_tactics.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Pero ni Villarrubia ni su camar&oacute;grafo confrontaron nunca a los dos hombres. Era poco probable que cooperaran y Villarrubia no quer&iacute;a darles detalles y hacerlos huir de La Solita, la cual estaba convenientemente ubicada cerca de una pista a&eacute;rea. Sobre todo, Villarrubia sab&iacute;a que los dos hombres estaban bien entrenados en artes marciales y armados. Este fue un per&iacute;odo de creciente violencia en el campo argentino; los homicidios y robos a mano armada aumentaron considerablemente. Villarrubia no quer&iacute;a correr el riesgo de convertirse en otro dato estad&iacute;stico. </span></p>
-<p><span>Por otra parte, &iquest;por cu&aacute;nto tiempo pod&iacute;a rastrear secretamente a los&nbsp;guardaespaldas de Schaefer? Sus editores en Santiago, comenzaron cuestionarse si este acercamiento podr&iacute;a rendir frutos. Hab&iacute;a llegado el mes de mayo y Villarrubia hab&iacute;a hecho varios viajes a Chivilcoy. Ya hab&iacute;a comprobado muchos de los h&aacute;bitos de los guardaespaldas, pero a&uacute;n no hab&iacute;a localizado a Schaefer</span>.</p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_515.html" class="page-previous" title="Go to previous page">&#171;&#160;El dilema de la c&aacute;mara oculta</a>
-
-<a href="case_id_50_id_517.html" class="page-next" title="Go to next page">¿Polic&iacute;as y ladrones?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Encubierto en Chivilcoy
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Encubierto en Chivilcoy
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En Chivilcoy, Villarrubia y su camarógrafo siguieron investigando quien vivía en La Solita. Para ello, la pareja utilizó algunos métodos innovadores para realizar un seguimiento de las actividades de Peter Schmidt y su cómplice, Friedhelm Zeitner (alias Felipe). Con el camarógrafo a cargo en la ciudad y Villarrubia cerca de La Solita, se comunicaban en código por teléfono para rastrear entradas y salidas de los alemanes. Se turnaban para seguirlos en coche y pronto comenzaron a surgir patrones en su forma de actuar. Cualquier persona que salía de la casa de Chivilcoy, Villarrubia notaba que seguía siempre un camino en círculo y sus viajes a la ciudad incluían frecuentemente una parada en un centro telefónico.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/207/082_083_1_villarrubia_on_tactics.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/WN4fjUuBhsc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Pero ni Villarrubia ni su camarógrafo confrontaron nunca a los dos hombres. Era poco probable que cooperaran y Villarrubia no quería darles detalles y hacerlos huir de La Solita, la cual estaba convenientemente ubicada cerca de una pista aérea. Sobre todo, Villarrubia sabía que los dos hombres estaban bien entrenados en artes marciales y armados. Este fue un período de creciente violencia en el campo argentino; los homicidios y robos a mano armada aumentaron considerablemente. Villarrubia no quería correr el riesgo de convertirse en otro dato estadístico.
+         </span>
+        </p>
+        <p>
+         <span>
+          Por otra parte, ¿por cuánto tiempo podía rastrear secretamente a los guardaespaldas de Schaefer? Sus editores en Santiago, comenzaron cuestionarse si este acercamiento podría rendir frutos. Había llegado el mes de mayo y Villarrubia había hecho varios viajes a Chivilcoy. Ya había comprobado muchos de los hábitos de los guardaespaldas, pero aún no había localizado a Schaefer
+         </span>
+         .
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_515.html" title="Go to previous page">
+          « El dilema de la cámara oculta
+         </a>
+         <a class="page-next" href="case_id_50_id_517.html" title="Go to next page">
+          ¿Policías y ladrones? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_517.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_517.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>¿Polic&iacute;as y ladrones? | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   ¿Policías y ladrones? | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,337 +84,268 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>¿Polic&iacute;as y ladrones?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">¿Polic&iacute;as y ladrones?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia era un veterano periodista de investigaci&oacute;n que hab&iacute;a trabajado en todo el mundo en historias sobre el tr&aacute;fico de drogas y el tr&aacute;fico il&iacute;cito de armas. El trabajo era frecuentemente en secreto y peligroso. En la medida que la investigaci&oacute;n continu&oacute; en Chivilcoy, los m&eacute;todos de Villarrubia, empezaron a parecerse cada vez m&aacute;s a los de un detective. En Santiago, el editor ejecutivo Baz&aacute;n Cardemil se hizo de nuevo un cuestionamiento acerca del trabajo que realizan en CONTACTO: &iquest;Cu&aacute;l era la l&iacute;nea divisoria entre una investigaci&oacute;n period&iacute;stica y una polic&iacute;aca?</span></p>
-<embed width="420" height="245" flashvars="file=../../files/videos/208/084_1_cardemil_journalist_involvement_dilemma.flv&amp;autostart=false" allowscriptaccess="always" allowfullscreen="true" quality="high" name="player" id="player" style="" src="player.swf" type="application/x-shockwave-flash"></embed>
-<p><span class="caption2">Baz&aacute;n Cardemil</span></p>
-<p><span>Aunque el equipo de Baz&aacute;n Cardemil estaba dispuesto a ir m&aacute;s all&aacute; en la definici&oacute;n de esta l&iacute;nea.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/209/085_086_1_rodriguez_fuentes_investigative_methods.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez &amp; Fuentes</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_516.html" class="page-previous" title="Go to previous page">&#171;&#160;Encubierto en Chivilcoy</a>
-
-<a href="case_id_50_id_518.html" class="page-next" title="Go to next page">Dudas en Santiago&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          ¿Policías y ladrones?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       ¿Policías y ladrones?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia era un veterano periodista de investigación que había trabajado en todo el mundo en historias sobre el tráfico de drogas y el tráfico ilícito de armas. El trabajo era frecuentemente en secreto y peligroso. En la medida que la investigación continuó en Chivilcoy, los métodos de Villarrubia, empezaron a parecerse cada vez más a los de un detective. En Santiago, el editor ejecutivo Bazán Cardemil se hizo de nuevo un cuestionamiento acerca del trabajo que realizan en CONTACTO: ¿Cuál era la línea divisoria entre una investigación periodística y una policíaca?
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/208/084_1_cardemil_journalist_involvement_dilemma.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/So3Ozm2dec0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Bazán Cardemil
+         </span>
+        </p>
+        <p>
+         <span>
+          Aunque el equipo de Bazán Cardemil estaba dispuesto a ir más allá en la definición de esta línea.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/209/085_086_1_rodriguez_fuentes_investigative_methods.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/1nhb-NL2mrc?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez &amp; Fuentes
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_516.html" title="Go to previous page">
+          « Encubierto en Chivilcoy
+         </a>
+         <a class="page-next" href="case_id_50_id_518.html" title="Go to next page">
+          Dudas en Santiago »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_518.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_518.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Dudas en Santiago | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Dudas en Santiago | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,340 +84,283 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Dudas en Santiago</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Dudas en Santiago</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Mientras tanto, el editor ejecutivo Baz&aacute;n Cardemil y el Editor Rodr&iacute;guez estaban cada vez m&aacute;s impacientes. Era ya el mes de&nbsp;julio y el segmento que ten&iacute;an la intenci&oacute;n de sacar al aire sobre&nbsp;Schaefer a&uacute;n no estaba listo. Villarrubia hab&iacute;a dedicado seis meses a una investigaci&oacute;n cada vez m&aacute;s costosa y aun no ten&iacute;a ninguna prueba real de que Schaefer estuviera en el complejo en Chivilcoy. La tensi&oacute;n en CONTACTO comenz&oacute; a escalar. Desde su posici&oacute;n en el campo de investigaci&oacute;n, Villarrubia ten&iacute;a fuertes sentimientos.</span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/210/092_089_1_villarrubia_editors_pressure.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Rodr&iacute;guez fue de los que mas presionaban a Villarrubia por los resultados. Se pregunt&oacute; cu&aacute;nto tiempo mas se tardar&iacute;a para encontrar algo y si realmente hab&iacute;a algo que encontrar en todo esto</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/211/090_1_rodriguez_expensive_gamble.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez</span></p>
-<p><span>Sin embargo, no hab&iacute;a un Plan B. Historias sobre la Colonia Dignidad se hab&iacute;an hecho anteriormente. A fin de justificar la difusi&oacute;n de una nueva historia sobre Paul Schaefer, CONTACTO tendr&iacute;a que encontrarlo. Fuentes y Villarrubia no estaban dispuestos a ceder, sino que defendieron con firmeza la investigaci&oacute;n y abogaron por que continuara</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/212/092_1_villarrubia_fuentes_dont_give_up.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_517.html" class="page-previous" title="Go to previous page">&#171;&#160;¿Polic&iacute;as y ladrones?</a>
-
-<a href="case_id_50_id_519.html" class="page-next" title="Go to next page">La Solita&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Dudas en Santiago
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Dudas en Santiago
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Mientras tanto, el editor ejecutivo Bazán Cardemil y el Editor Rodríguez estaban cada vez más impacientes. Era ya el mes de julio y el segmento que tenían la intención de sacar al aire sobre Schaefer aún no estaba listo. Villarrubia había dedicado seis meses a una investigación cada vez más costosa y aun no tenía ninguna prueba real de que Schaefer estuviera en el complejo en Chivilcoy. La tensión en CONTACTO comenzó a escalar. Desde su posición en el campo de investigación, Villarrubia tenía fuertes sentimientos.
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/210/092_089_1_villarrubia_editors_pressure.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/J9KUoBtirOA?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Rodríguez fue de los que mas presionaban a Villarrubia por los resultados. Se preguntó cuánto tiempo mas se tardaría para encontrar algo y si realmente había algo que encontrar en todo esto
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/211/090_1_rodriguez_expensive_gamble.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/ORX7fsmpio0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez
+         </span>
+        </p>
+        <p>
+         <span>
+          Sin embargo, no había un Plan B. Historias sobre la Colonia Dignidad se habían hecho anteriormente. A fin de justificar la difusión de una nueva historia sobre Paul Schaefer, CONTACTO tendría que encontrarlo. Fuentes y Villarrubia no estaban dispuestos a ceder, sino que defendieron con firmeza la investigación y abogaron por que continuara
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/212/092_1_villarrubia_fuentes_dont_give_up.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/7TD_Ol6b1K0?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_517.html" title="Go to previous page">
+          « ¿Policías y ladrones?
+         </a>
+         <a class="page-next" href="case_id_50_id_519.html" title="Go to next page">
+          La Solita »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_519.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_519.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>La Solita | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   La Solita | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,339 +84,283 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>La Solita</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<!-- Primary links, if enabled -->
-
-
-<!-- Secondary links, if enabled -->
-
-     <!-- <div></div> -->
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-
-
-
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  class="active"  href="case_id_50_id_519.html">La Solita</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a>
-
-
-
-
-
-</li>
-
-
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-
-
-
-
-
-</li>
-
-
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">La Solita</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia decidi&oacute; intensificar su investigaci&oacute;n en la comunidad de La Solita. A excepci&oacute;n del movimiento que hab&iacute;a observado en sus campos, el rancho era todav&iacute;a un misterio. Fue cerrado a los visitantes. Los vecinos que quer&iacute;an visitar ten&iacute;an que llamar a la casa con anticipaci&oacute;n para concertar una cita y dar tiempo a los alemanes a activar sus mecanismos de seguridad. La casa principal estaba oculta en lo m&aacute;s apartado de la gran propiedad y rodeada de altos &aacute;rboles, lo cual hac&iacute;a que el movimiento en la casa fuese imposible de poder observar. De hecho, la &uacute;nica percepci&oacute;n que Villarrubia tuvo de la casa principal del rancho, fue cuando en marzo, &eacute;l y Fuentes alquilaron un avi&oacute;n. </span></p>
-<p><span>Frustrado por su falta de progreso despu&eacute;s de meses de investigaci&oacute;n y actuando por capricho, Villarrubia decidi&oacute; a trav&eacute;s de una actitud m&aacute;s radical de acci&oacute;n: entrar en La Solita. Pens&oacute; que tal vez podr&iacute;a ubicar a Paul Schaefer. Una oportunidad se present&oacute; cuando Villarrubia sugiri&oacute; a uno de los trabajadores de Hugo Placente que llevaran su becerro reci&eacute;n nacido a La Solita para ser vacunado. Los alemanes ten&iacute;an el conocimiento y el equipo para atender este asunto, por lo que el trabajador de la granja r&aacute;pidamente estuvo de acuerdo</span><span>. </span></p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/213/094_1_villarrubia_entering_la_solita.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Finalmente, se permiti&oacute; a los dos hombres el ingreso a los terrenos</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/214/095_096_1_villarrubia_camera_loses_signal.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Aterrorizado, Villarrubia consult&oacute; con sus amigos en Buenos Aires para averiguar qu&eacute; hab&iacute;a sucedido con su c&aacute;mara. Sucedi&oacute; que, los alemanes, tan pronto como Villarrubia son&oacute; el timbre de la puerta, estos ya hab&iacute;an activado un campo electromagn&eacute;tico alrededor de La Solita, para neutralizar cualquier actividad de grabaci&oacute;n</span>.</p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_518.html" class="page-previous" title="Go to previous page">&#171;&#160;Dudas en Santiago</a>
-
-<a href="case_id_50_id_520.html" class="page-next" title="Go to next page">Un avance&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          La Solita
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <!-- Primary links, if enabled -->
+   <!-- Secondary links, if enabled -->
+   <!-- <div></div> -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       La Solita
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia decidió intensificar su investigación en la comunidad de La Solita. A excepción del movimiento que había observado en sus campos, el rancho era todavía un misterio. Fue cerrado a los visitantes. Los vecinos que querían visitar tenían que llamar a la casa con anticipación para concertar una cita y dar tiempo a los alemanes a activar sus mecanismos de seguridad. La casa principal estaba oculta en lo más apartado de la gran propiedad y rodeada de altos árboles, lo cual hacía que el movimiento en la casa fuese imposible de poder observar. De hecho, la única percepción que Villarrubia tuvo de la casa principal del rancho, fue cuando en marzo, él y Fuentes alquilaron un avión.
+         </span>
+        </p>
+        <p>
+         <span>
+          Frustrado por su falta de progreso después de meses de investigación y actuando por capricho, Villarrubia decidió a través de una actitud más radical de acción: entrar en La Solita. Pensó que tal vez podría ubicar a Paul Schaefer. Una oportunidad se presentó cuando Villarrubia sugirió a uno de los trabajadores de Hugo Placente que llevaran su becerro recién nacido a La Solita para ser vacunado. Los alemanes tenían el conocimiento y el equipo para atender este asunto, por lo que el trabajador de la granja rápidamente estuvo de acuerdo
+         </span>
+         <span>
+          .
+         </span>
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/213/094_1_villarrubia_entering_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/NGkceP6qk1s?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Finalmente, se permitió a los dos hombres el ingreso a los terrenos
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/214/095_096_1_villarrubia_camera_loses_signal.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/QbBSqXPih_w?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Aterrorizado, Villarrubia consultó con sus amigos en Buenos Aires para averiguar qué había sucedido con su cámara. Sucedió que, los alemanes, tan pronto como Villarrubia sonó el timbre de la puerta, estos ya habían activado un campo electromagnético alrededor de La Solita, para neutralizar cualquier actividad de grabación
+         </span>
+         .
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_518.html" title="Go to previous page">
+          « Dudas en Santiago
+         </a>
+         <a class="page-next" href="case_id_50_id_520.html" title="Go to next page">
+          Un avance »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_520.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_520.html
@@ -1,44 +1,59 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>Un avance | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Un avance | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -46,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -72,196 +84,278 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>Un avance</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-
-<div id="pagebody">
-
-	
-	<!-- Left sidebar --><div id="sidebar-left">
-
-		  <div class="block block-menu" id="block-menu-63">
-    <h2 class="title">Sections</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><a  href="case_id_50.html">Title Page</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a>
-</li>
-<li class="leaf"><a  class="active"  href="case_id_50_id_520.html">Un avance</a>
-</li>
-<li class="leaf"><a  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a>
-</li>
-</ul>
-</div>
- </div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">Un avance</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>En el transcurso del oto&ntilde;o de 2004, Villarrubia sigue desafiando el escepticismo de los editores y visita Chivilcoy. En el mes de octubre pas&oacute; un tiempo en el rancho de Hugo Placente, donde fue capaz de juntar m&aacute;s piezas del rompecabezas del entorno de Schaefer. Estaba seguro de que todos los actores principales estaban actualmente en La Solita. Descubri&oacute; por ejemplo, que un joven que parec&iacute;a m&aacute;s hispano que los guardaespaldas alemanes era en realidad &quot;Martin,&quot; el alias de Matthias Gerlach, un chileno que hab&iacute;a sido adoptado y era el favorito de Schaefer. Su presencia en el rancho era significativa. </span></p>
-<p><span>A Felipe el guardaespaldas, siempre le hab&iacute;a parecido sospechoso Villarrubia y al parecer manten&iacute;a cierta distancia para evitarlo. Sin embargo, en una ocasi&oacute;n, Felipe lleg&oacute; con regalos de quesos de La Solita, a fin de hablar de negocios con Placente. A principios de noviembre de 2004, una de estas visitas rindi&oacute; sus frutos</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/215/098_1_villarrubia_schaefer_is_alive.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Lo que es m&aacute;s, la observaci&oacute;n minuciosa de Villarrubia sobre los movimientos en La Solita hab&iacute;a resultando de utilidad</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/216/099_1_villarrubia_everyone_at_la_solita.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>A mediados de noviembre, Villarrubia sab&iacute;a que hab&iacute;a llegado el momento de actuar</span>.</p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_519.html" class="page-previous" title="Go to previous page">&#171;&#160;La Solita</a>
-
-<a href="case_id_50_id_521.html" class="page-next" title="Go to next page">&iquest;Sin Alternativas?&#160;&#187;</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          Un avance
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
- </div>
-			</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       Un avance
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          En el transcurso del otoño de 2004, Villarrubia sigue desafiando el escepticismo de los editores y visita Chivilcoy. En el mes de octubre pasó un tiempo en el rancho de Hugo Placente, donde fue capaz de juntar más piezas del rompecabezas del entorno de Schaefer. Estaba seguro de que todos los actores principales estaban actualmente en La Solita. Descubrió por ejemplo, que un joven que parecía más hispano que los guardaespaldas alemanes era en realidad "Martin," el alias de Matthias Gerlach, un chileno que había sido adoptado y era el favorito de Schaefer. Su presencia en el rancho era significativa.
+         </span>
+        </p>
+        <p>
+         <span>
+          A Felipe el guardaespaldas, siempre le había parecido sospechoso Villarrubia y al parecer mantenía cierta distancia para evitarlo. Sin embargo, en una ocasión, Felipe llegó con regalos de quesos de La Solita, a fin de hablar de negocios con Placente. A principios de noviembre de 2004, una de estas visitas rindió sus frutos
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/215/098_1_villarrubia_schaefer_is_alive.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/UjJJTFpNps8?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Lo que es más, la observación minuciosa de Villarrubia sobre los movimientos en La Solita había resultando de utilidad
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/216/099_1_villarrubia_everyone_at_la_solita.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/N6MBBRDB8jE?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          A mediados de noviembre, Villarrubia sabía que había llegado el momento de actuar
+         </span>
+         .
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_519.html" title="Go to previous page">
+          « La Solita
+         </a>
+         <a class="page-next" href="case_id_50_id_521.html" title="Go to next page">
+          ¿Sin Alternativas? »
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>

--- a/casestudies/50/casestudy/www/layout/case_id_50_id_521.html
+++ b/casestudies/50/casestudy/www/layout/case_id_50_id_521.html
@@ -1,46 +1,59 @@
-
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-
-
-<head>
-  <title>&iquest;Sin Alternativas? | &iquest;Periodistas o polic&iacute;as? CONTACTO y la b&uacute;squeda de Paul Schaefer
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   ¿Sin Alternativas? | ¿Periodistas o policías? CONTACTO y la búsqueda de Paul Schaefer
   </title>
- 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-<link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-
-  <style type="text/css" media="all">@import "css_global/book/book.css";</style>
-<style type="text/css" media="all">@import "css_global/node/node.css";</style>
-<style type="text/css" media="all">@import "css_global/system/defaults.css";</style>
-<style type="text/css" media="all">@import "css_global/system/system.css";</style>
-<style type="text/css" media="all">@import "css_global/user/user.css";</style>
-<style type="text/css" media="all">@import "css_global/img_assist/img_assist.css";</style>
-<style type="text/css" media="all">@import "css_global/knightcase/style.css";</style>
-<style type="text/css" media="print">@import "css_global/knightcase/print.css";</style>
-<script type="text/javascript" src="com/jquery/jquery-1.2.6.js"></script>
-<script type="text/javascript" src="js/img_assist.js"></script>
-<script type="text/javascript" src="js/audioimage.js"></script>
-<script type="text/javascript" src="com/jquery/jquery.metadata.js"></script> 
-<script type="text/javascript" src="com/jquery/jquery.media.js"></script> 
-<script type="text/javascript" src="swfobject.js"></script> 
-
- <script type="text/javascript">
-        var GB_ROOT_DIR = "com/greybox/";
-    </script>
-
-    <script type="text/javascript" src="com/greybox/AJS.js"></script>
-    <script type="text/javascript" src="com/greybox/AJS_fx.js"></script>
-
-    <script type="text/javascript" src="com/greybox/gb_scripts.js"></script>
-    <link href="com/greybox/gb_styles.css" rel="stylesheet" type="text/css" media="all" />
-	
-
-
-    <script type="text/javascript">
-      var GB_ANIMATION = true;
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+  <style media="all" type="text/css">
+   @import "css_global/book/book.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/node/node.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/defaults.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/system/system.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/user/user.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/img_assist/img_assist.css";
+  </style>
+  <style media="all" type="text/css">
+   @import "css_global/knightcase/style.css";
+  </style>
+  <style media="print" type="text/css">
+   @import "css_global/knightcase/print.css";
+  </style>
+  <script src="com/jquery/jquery-1.2.6.js" type="text/javascript">
+  </script>
+  <script src="js/img_assist.js" type="text/javascript">
+  </script>
+  <script src="js/audioimage.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.metadata.js" type="text/javascript">
+  </script>
+  <script src="com/jquery/jquery.media.js" type="text/javascript">
+  </script>
+  <script src="swfobject.js" type="text/javascript">
+  </script>
+  <script type="text/javascript">
+   var GB_ROOT_DIR = "com/greybox/";
+  </script>
+  <script src="com/greybox/AJS.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/AJS_fx.js" type="text/javascript">
+  </script>
+  <script src="com/greybox/gb_scripts.js" type="text/javascript">
+  </script>
+  <link href="com/greybox/gb_styles.css" media="all" rel="stylesheet" type="text/css"/>
+  <script type="text/javascript">
+   var GB_ANIMATION = true;
       $(document).ready(function(){
         $("a.greybox").click(function(){
           var t = this.title || this.innerHTML || this.href;
@@ -48,17 +61,14 @@
           return false;
         });
       });
-    </script>
-
-
-<script type="text/javascript">
-    $(function() {
+  </script>
+  <script type="text/javascript">
+   $(function() {
         $('a.media').media();
     });
-</script>
-
-<style>
-#main .title
+  </script>
+  <style>
+   #main .title
 {
 	color: #e8123d;
 	font: normal 1.8em "trebuchet ms", verdana, helvetica, arial, sans-serif;
@@ -74,170 +84,280 @@
 #media {
 font-style:italic;
 }
-
-
-
-</style>
-<link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-<script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
-</head>
-
-<body>
-
-<div id="container">
-
-<!-- Banner header -->
-
-<div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
-<table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td style="width: 100%;">
-		<h1 class='site-name'><a href="case_id_50.html" title="Home"><span>&iquest;Sin Alternativas?</span></a></h1>						</td>
-		<td class="kcsi_logo"><a href="https://casestudies.jrn.columbia.edu/" target="_blank" class="knightlogo"></a></td>
-	</tr>
-
-</table>
-      
-      
-</div><!-- id="header" -->
-
-
-<div id="pagebody">
-<!-- Left sidebar --><div id="sidebar-left">
-<div class="block block-menu" id="block-menu-63">
-<h2 class="title">Sections</h2>
-<div class="content">
-<ul class="menu">
-<li class="leaf"><a  href="case_id_50.html">Title Page</a></li>
-<li class="leaf"><a  href="case_id_50_id_504.html">Introducci&oacute;n</a></li>
-<li class="leaf"><a  href="case_id_50_id_505.html">Paul Schaefer</a></li>
-<li class="leaf"><a  href="case_id_50_id_506.html">Schaefer y las autoridades chilenas</a></li>
-<li class="leaf"><a  href="case_id_50_id_507.html">CONTACTO</a></li>
-<li class="leaf"><a  href="case_id_50_id_508.html">Indicios hacia Argentina</a></li>
-<li class="leaf"><a  href="case_id_50_id_509.html">Chivilcoy</a></li>
-<li class="leaf"><a  href="case_id_50_id_510.html">&iquest;Se justifica ir encubierto?</a></li>
-<li class="leaf"><a  href="case_id_50_id_511.html">Profundizando en la Investigaci&oacute;n</a></li>
-<li class="leaf"><a  href="case_id_50_id_512.html">Hugo Placente</a></li>
-<li class="leaf"><a  href="case_id_50_id_513.html">Gente peligrosa</a></li>
-<li class="leaf"><a  href="case_id_50_id_514.html">El Segundo Viaje&#8212;a Desenmascarar</a></li>
-<li class="leaf"><a  href="case_id_50_id_515.html">El dilema de la c&aacute;mara oculta</a></li>
-<li class="leaf"><a  href="case_id_50_id_516.html">Encubierto en Chivilcoy</a></li>
-<li class="leaf"><a  href="case_id_50_id_517.html">¿Polic&iacute;as y ladrones?</a></li>
-<li class="leaf"><a  href="case_id_50_id_518.html">Dudas en Santiago</a></li>
-<li class="leaf"><a  href="case_id_50_id_519.html">La Solita</a></li>
-<li class="leaf"><a  href="case_id_50_id_520.html">Un avance</a></li>
-<li class="leaf"><a  class="active"  href="case_id_50_id_521.html">&iquest;Sin Alternativas?</a></li>
-</ul>
-</div>
-</div>
-
-  <div class="block block-block" id="block-block-1">
-    <h2 class="title"></h2>
-
-	
-    <div class="content"><div class="content">
-<ul class="menu">
-<li class="printpdf">
-<a href="../../files/global/50/CONTACTO&#32;y&#32;la&#32;bussqueda&#32;de&#32;Paul&#32;Schaefer_wm.pdf" target="_blank">Download this case as a PDF</a></li>
-</ul>
-</div>
-</div>
-
-
- </div>
-	</div><!-- id="sidebar-left" -->
-	
-	<!-- Main content of page -->
-	
-	<div id="contentbody" class="three-column" >
-				
-		<div id="main">
-		<div class="breadcrumb"><a href="case_id_50.html">Home</a> 
-		
-		
-		
-		
-		</div>		
-		<h1 class="title">&iquest;Sin Alternativas?</h1>
-		
-		
-		
-		<div class="tabs"></div>
-
-		
-	  <div class="node">
-    <span class="taxonomy"></span>
-    <div class="content"><p><span>Villarrubia regres&oacute; a Santiago y describi&oacute; los resultados al resto del equipo. Baz&aacute;n Cardemil sab&iacute;a que era hora de acercarse a las autoridades. Percib&iacute;a que la investigaci&oacute;n de CONTACTO, no pod&iacute;a continuar por su cuenta. Sin embargo, los miembros del equipo se mostraron cautelosos de acercarse a las autoridades, por varias razones</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/217/104_102_1_rodriguez_villarrubia_doubts_about_police.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Rodr&iacute;guez &amp; Villarrubia</span></p>
-<p><span>El reportero Fuentes ten&iacute;a miedo de confiar en las autoridades argentinas. Despu&eacute;s de todo, la polic&iacute;a chilena probablemente hab&iacute;a ayudado a Schaefer escapar de la detenci&oacute;n en 1997. &iquest;Qui&eacute;n pod&iacute;a decir que la polic&iacute;a argentina fuera m&aacute;s confiable? En cambio, ella y el abogado de las v&iacute;ctimas de Schaefer, Fern&aacute;ndez, decidieron explorar otras v&iacute;as, tales como dos organizaciones de derechos humanos, pero no efectivas. </span></p>
-<p><span>Otra opci&oacute;n era acercarse a la Interpol, pol&iacute;ticamente neutral, agencia de polic&iacute;a internacional que podr&iacute;a realizar el seguimiento de criminales a trav&eacute;s de las fronteras. Pero &iquest;Qu&eacute; tal si Schaefer tenia protecci&oacute;n tambi&eacute;n de estos? Schaefer, despu&eacute;s de todo, era experto en el desarrollo de protecci&oacute;n donde lo necesitaba. Incluso si la organizaci&oacute;n de la polic&iacute;a fuera incorrupta, &iquest;qu&eacute; pasar&iacute;a si los investigadores de Interpol aceptaran la evidencia que el equipo de CONTACTO&nbsp;hab&iacute;a reunido durante el a&ntilde;o pasado, pero no les permitiera filmar el momento de la detenci&oacute;n? Sin la grabaci&oacute;n de este momento en la cinta, cualquier documental resultante se debilitar&iacute;a&nbsp;significativamente. &iquest;Podr&iacute;a CONTACTO poner en riesgo el fallar a s&iacute; mismo, despu&eacute;s de todo el tiempo y recursos que le hab&iacute;an dedicado al proyecto?</span></p>
-<p><span>Mientras debat&iacute;an sus opciones, Villarrubia hab&iacute;a vuelto una vez m&aacute;s a Chivilcoy a mantener el ojo sobre la situaci&oacute;n. Cuando lleg&oacute;, encontr&oacute; que la situaci&oacute;n se hab&iacute;a vuelto mucho m&aacute;s tensa. Los alemanes en La Solita hab&iacute;an comenzado a sospechar sobre su investigaci&oacute;n y empezaron a preguntar a sus vecinos acerca de Villarrubia. Pronto comenzaron a decirles a los vecinos que Villarrubia era un esp&iacute;a de la CIA. Entonces, Villarrubia tuvo un alarmante encuentro con Peter Schmidt, el guardaespaldas principal y m&aacute;s peligroso de los residentes de La Solita</span>.</p>
-<embed width="420" height="245" type="application/x-shockwave-flash" src="player.swf" style="" id="player" name="player" quality="high" allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/218/106_1_villarrubia_confrontation_peter_schmidt.flv&amp;autostart=false"></embed>
-<p><span class="caption2">Villarrubia</span></p>
-<p><span>Evidentemente, el tiempo se agotaba para Villarrubia y su investigaci&oacute;n encubierta. El equipo de CONTACTO sab&iacute;a que hab&iacute;a llegado el momento de actuar, antes de que Schaefer escapara de nuevo. Justo lo que esa acci&oacute;n debi&oacute; de haber sido, sin embargo, estaba lejos de quedar clara</span>.</p></div>
-
-
-<div class="book-navigation" style="clear:both"><div class="page-links clear-block">
-
-
-<a href="case_id_50_id_520.html" class="page-previous" title="Go to previous page">&#171;&#160;Un avance</a>
-
-</div>
-</div></div>
-
+  </style>
+  <link href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" rel="stylesheet"/>
+  <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js">
+  </script>
+ </head>
+ <body>
+  <div id="container">
+   <!-- Banner header -->
+   <div id="header" style="background: url('../../files/global/50/knightcase_logo_contacto_espanol.JPG') top left no-repeat;">
+    <table border="0" cellpadding="0" cellspacing="0">
+     <tr>
+      <td style="width: 100%;">
+       <h1 class="site-name">
+        <a href="case_id_50.html" title="Home">
+         <span>
+          ¿Sin Alternativas?
+         </span>
+        </a>
+       </h1>
+      </td>
+      <td class="kcsi_logo">
+       <a class="knightlogo" href="https://casestudies.jrn.columbia.edu/" target="_blank">
+       </a>
+      </td>
+     </tr>
+    </table>
+   </div>
+   <!-- id="header" -->
+   <div id="pagebody">
+    <!-- Left sidebar -->
+    <div id="sidebar-left">
+     <div class="block block-menu" id="block-menu-63">
+      <h2 class="title">
+       Sections
+      </h2>
+      <div class="content">
+       <ul class="menu">
+        <li class="leaf">
+         <a href="case_id_50.html">
+          Title Page
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_504.html">
+          Introducción
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_505.html">
+          Paul Schaefer
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_506.html">
+          Schaefer y las autoridades chilenas
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_507.html">
+          CONTACTO
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_508.html">
+          Indicios hacia Argentina
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_509.html">
+          Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_510.html">
+          ¿Se justifica ir encubierto?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_511.html">
+          Profundizando en la Investigación
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_512.html">
+          Hugo Placente
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_513.html">
+          Gente peligrosa
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_514.html">
+          El Segundo Viaje—a Desenmascarar
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_515.html">
+          El dilema de la cámara oculta
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_516.html">
+          Encubierto en Chivilcoy
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_517.html">
+          ¿Policías y ladrones?
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_518.html">
+          Dudas en Santiago
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_519.html">
+          La Solita
+         </a>
+        </li>
+        <li class="leaf">
+         <a href="case_id_50_id_520.html">
+          Un avance
+         </a>
+        </li>
+        <li class="leaf">
+         <a class="active" href="case_id_50_id_521.html">
+          ¿Sin Alternativas?
+         </a>
+        </li>
+       </ul>
       </div>
-				</div><!-- id="main" -->
-	</div><!-- id="contentbody" -->
-		<!-- Right sidebar for Bios -->
-	<div id="sidebar-right">
-		  <div class="block block-menu" id="block-menu-65">
-    <h2 class="title">Biographies</h2>
-    <div class="content">
-<ul class="menu">
-
-
-</ul>
-</div>
- </div>
-	</div><!-- id="sidebar-right" -->
-	
-
-	
-	<div class="visualclear"></div>
-
-
-</div><!-- id="pagebody" -->
-
-
-
-<div style="clear: both;"></div>
-<div id="footer">
-	<div id="footer-inner">
-	  <div class="block block-menu" id="block-menu-66">
-    <h2 class="title">System menu</h2>
-    <div class="content">
-<ul class="menu">
-<li class="leaf"><!-- copyright notice --></li>
-
-</ul>
-</div>
-</div>
-</div><!-- id="footer-inner" -->
-
-</div><!-- id="footer" -->
-
-</div><!-- id="container" -->
-
-<script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+     </div>
+     <div class="block block-block" id="block-block-1">
+      <h2 class="title">
+      </h2>
+      <div class="content">
+       <div class="content">
+        <ul class="menu">
+         <li class="printpdf">
+          <a href="../../files/global/50/CONTACTO y la bussqueda de Paul Schaefer_wm.pdf" target="_blank">
+           Download this case as a PDF
+          </a>
+         </li>
+        </ul>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="sidebar-left" -->
+    <!-- Main content of page -->
+    <div class="three-column" id="contentbody">
+     <div id="main">
+      <div class="breadcrumb">
+       <a href="case_id_50.html">
+        Home
+       </a>
+      </div>
+      <h1 class="title">
+       ¿Sin Alternativas?
+      </h1>
+      <div class="tabs">
+      </div>
+      <div class="node">
+       <span class="taxonomy">
+       </span>
+       <div class="content">
+        <p>
+         <span>
+          Villarrubia regresó a Santiago y describió los resultados al resto del equipo. Bazán Cardemil sabía que era hora de acercarse a las autoridades. Percibía que la investigación de CONTACTO, no podía continuar por su cuenta. Sin embargo, los miembros del equipo se mostraron cautelosos de acercarse a las autoridades, por varias razones
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/217/104_102_1_rodriguez_villarrubia_doubts_about_police.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/6dZRvVMbY28?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Rodríguez &amp; Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          El reportero Fuentes tenía miedo de confiar en las autoridades argentinas. Después de todo, la policía chilena probablemente había ayudado a Schaefer escapar de la detención en 1997. ¿Quién podía decir que la policía argentina fuera más confiable? En cambio, ella y el abogado de las víctimas de Schaefer, Fernández, decidieron explorar otras vías, tales como dos organizaciones de derechos humanos, pero no efectivas.
+         </span>
+        </p>
+        <p>
+         <span>
+          Otra opción era acercarse a la Interpol, políticamente neutral, agencia de policía internacional que podría realizar el seguimiento de criminales a través de las fronteras. Pero ¿Qué tal si Schaefer tenia protección también de estos? Schaefer, después de todo, era experto en el desarrollo de protección donde lo necesitaba. Incluso si la organización de la policía fuera incorrupta, ¿qué pasaría si los investigadores de Interpol aceptaran la evidencia que el equipo de CONTACTO había reunido durante el año pasado, pero no les permitiera filmar el momento de la detención? Sin la grabación de este momento en la cinta, cualquier documental resultante se debilitaría significativamente. ¿Podría CONTACTO poner en riesgo el fallar a sí mismo, después de todo el tiempo y recursos que le habían dedicado al proyecto?
+         </span>
+        </p>
+        <p>
+         <span>
+          Mientras debatían sus opciones, Villarrubia había vuelto una vez más a Chivilcoy a mantener el ojo sobre la situación. Cuando llegó, encontró que la situación se había vuelto mucho más tensa. Los alemanes en La Solita habían comenzado a sospechar sobre su investigación y empezaron a preguntar a sus vecinos acerca de Villarrubia. Pronto comenzaron a decirles a los vecinos que Villarrubia era un espía de la CIA. Entonces, Villarrubia tuvo un alarmante encuentro con Peter Schmidt, el guardaespaldas principal y más peligroso de los residentes de La Solita
+         </span>
+         .
+        </p>
+        <!--<embed allowfullscreen="true" allowscriptaccess="always" flashvars="file=../../files/videos/218/106_1_villarrubia_confrontation_peter_schmidt.flv&amp;autostart=false" height="245" id="player" name="player" quality="high" src="player.swf" style="" type="application/x-shockwave-flash" width="420"/>-->
+        <iframe frameborder="0" height="270" src="https://www.youtube.com/embed/iMFsOjtfhyU?rel=0&amp;modestbranding=1&amp;autohide=1&amp;showinfo=0" type="text/html" width="480">
+        </iframe>
+        <p>
+         <span class="caption2">
+          Villarrubia
+         </span>
+        </p>
+        <p>
+         <span>
+          Evidentemente, el tiempo se agotaba para Villarrubia y su investigación encubierta. El equipo de CONTACTO sabía que había llegado el momento de actuar, antes de que Schaefer escapara de nuevo. Justo lo que esa acción debió de haber sido, sin embargo, estaba lejos de quedar clara
+         </span>
+         .
+        </p>
+       </div>
+       <div class="book-navigation" style="clear:both">
+        <div class="page-links clear-block">
+         <a class="page-previous" href="case_id_50_id_520.html" title="Go to previous page">
+          « Un avance
+         </a>
+        </div>
+       </div>
+      </div>
+     </div>
+    </div>
+    <!-- id="main" -->
+   </div>
+   <!-- id="contentbody" -->
+   <!-- Right sidebar for Bios -->
+   <div id="sidebar-right">
+    <div class="block block-menu" id="block-menu-65">
+     <h2 class="title">
+      Biographies
+     </h2>
+     <div class="content">
+      <ul class="menu">
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="sidebar-right" -->
+   <div class="visualclear">
+   </div>
+  </div>
+  <!-- id="pagebody" -->
+  <div style="clear: both;">
+  </div>
+  <div id="footer">
+   <div id="footer-inner">
+    <div class="block block-menu" id="block-menu-66">
+     <h2 class="title">
+      System menu
+     </h2>
+     <div class="content">
+      <ul class="menu">
+       <li class="leaf">
+        <!-- copyright notice -->
+       </li>
+      </ul>
+     </div>
+    </div>
+   </div>
+   <!-- id="footer-inner" -->
+  </div>
+  <!-- id="footer" -->
+  <!-- id="container" -->
+  <script type="text/javascript">
+   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-try {
+  </script>
+  <script type="text/javascript">
+   try {
 var pageTracker = _gat._getTracker("UA-51144540-10");
 pageTracker._trackPageview();
-} catch(err) {}</script>
-
-</body>
+} catch(err) {}
+  </script>
+ </body>
 </html>


### PR DESCRIPTION
This PR replaces all the `<embed>` flavors of flash video with YouTube iFrames. The files were also reencoded to utf-8 via BeautifulSoup. 